### PR TITLE
Added GamepadPose

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,13 @@
 
         </dd>
 
+        <dt>readonly attribute GamepadPose? pose</dt>
+        <dd>
+          The current pose of the gamepad, if suppoerted by the hardware.
+          Includes position, orientation, and acceleration. If the hardware
+          cannot supply any pose values MUST be set to null.
+        </dd>
+
       </dl>
     </section>
 
@@ -361,6 +368,85 @@
 
           For buttons without an analog sensor, only the values 0.0 and 1.0
           for fully unpressed and fully pressed MUST be provided.
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadPose</dfn> Interface</h2>
+      <p>
+        This interface defines the gamepad's position, orientation, and
+        acceleration.
+      </p>
+
+      <dl title='interface GamepadPose' class='idl'>
+        <dt>readonly attribute Float32Array? position</dt>
+        <dd>
+          Position of the gamepad as a 3D vector. Position is given in meters
+          from an origin point, which is determined by the gamepad hardware, and
+          may be the position of the gamepad when first polled if no other
+          reference point is available. The coordinate system uses these axis
+          definitions, assuming the user is holding the gamepad in the forward
+          orientation:
+
+          <ul>
+            <li>Positive X is to the user's right.</li>
+            <li>Positive Y is up.</li>
+            <li>Positive Z is behind the user.</li>
+          </ul>
+
+          MUST be null if the gamepad is incapable of providing positional data.
+          When not null MUST be a three-element array.
+        </dd>
+
+        <dt>readonly attribute Float32Array? linearVelocity</dt>
+        <dd>
+          Linear velocity of the gamepad in meters per second. MUST be null if
+          the sensor is incapable of providing linear velocity. When not null
+          MUST be a three-element array.
+        </dd>
+
+        <dt>readonly attribute Float32Array? linearAcceleration</dt>
+        <dd>
+          Linear acceleration of the gamepad in meters per second. MUST be null
+          if the sensor is incapable of providing linear acceleration. When not
+          null MUST be a three-element array.
+        </dd>
+
+        <dt>readonly attribute Float32Array? orientation</dt>
+        <dd>
+          Orientation of the gamepad as a quaternion. An orientation of
+          [0, 0, 0, 1] is considered to be "forward". The forward direction is
+          determined by the gamepad hardware, and may be the orientation of the
+          hardware when it was first polled if no other reference orientation is
+          available. MUST be null if the sensor is incapable of providing
+          orientation data. When not null MUST be a four-element array.
+        </dd>
+
+        <dt>readonly attribute Float32Array? angularVelocity</dt>
+        <dd>
+          Angular velocity of the gamepad in meters per second. MUST be null if
+          the sensor is incapable of providing angular velocity. When not null
+          MUST be a three-element array.
+        </dd>
+
+        <dt>readonly attribute Float32Array? angularAcceleration</dt>
+        <dd>
+          Angular acceleration of the gamepad in meters per second. MUST be null
+          if the sensor is incapable of providing angular acceleration. When not
+          null MUST be a three-element array.
+        </dd>
+
+        <dt>readonly attribute boolean hasPosition</dt>
+        <dd>
+          The hasPosition attribute MUST return whether the gamepad is capable
+          of tracking its position.
+        </dd>
+
+        <dt>readonly attribute boolean hasOrientation</dt>
+        <dd>
+          The hasOrientation attribute MUST return whether the gamepad is
+          capable of tracking its orientation.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
This is my proposal for adding motion, orientation, and position tracking to the Gamepad spec. Seems like creating a pull request here may be a more productive way to fostering conversation around the feature than the mailing list, which was relatively quiet on the subject.

The new interfaces are closely modeled after the VRDisplayPose and VRDisplayCapabilities interfaces defined in the [WebVR spec](https://w3c.github.io/webvr/), and I expect that they will commonly be used in conjunction. I've already prototyped exposing the device pose like this in my [experimental WebVR builds](https://webvr.info/get-chrome) and the community has taken to it fairly enthusiastically:

http://elevr.com/drawing-in-webvr/
https://twitter.com/mrdoob/status/742582533561290752
https://twitter.com/fernandojsg/status/740685191581175810
https://twitter.com/fernandojsg/status/737356455737712642
https://twitter.com/gordonnl/status/742920230498799616

Despite having it's origins in VR, however, I don't feel this features should explicitly be tied to the WebVR spec since it could benefit many more traditional gamepads as well. The Wii remote or PS4 controllers could provide accelerometer and orientation data, for example.

GamepadCapabilities is added here to make explicit wether or not a device can communicate position or orientation, since those values may not always be available continuously and it's important for developers to disambiguate between the hardware not having the capability at all (`capabilities.hasPosition = false`) or the device momentarily losing tracking because, say, a cat walked in front of an external sensor. (`pose.position = null`) There is no `hasPose` in the capabilities interface because that should be implied by the pose attribute being `null`. I would expect that this interface would be expanded in the future to cover similar capabilities (`canVibrate`, perhaps?)

Very happy to discuss this further and/or clean up the pull request to clarify things! Thanks!
