### PR TITLE
Added touched property to GamepadButton

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,10 +338,16 @@
 
         <dt>readonly attribute boolean touched</dt>
         <dd>
-          The touched state of the button. This property MUST be true if the
-          button is capable of detecting touch and is currently touched. If the
-          button is not capable of detecting touch or is not currently touched
-          this property MUST be false.
+          The touched state of the button. If the button is capable of detecting
+          touch this property MUST be true if the button is currently being
+          touched and false otherwise.
+
+          If the button is not capable of detecting touch and is capable of
+          reporting an analog value this property MUST be true if
+          the value property is greater than zero and false if the value is 0.
+
+          If the button is not capable of detecting touch and can only report a
+          digital value this property MUST mirror the pressed value.
         </dd>
 
         <dt>readonly attribute double value</dt>

--- a/index.html
+++ b/index.html
@@ -336,6 +336,14 @@
           reasonable value.
         </dd>
 
+        <dt>readonly attribute boolean touched</dt>
+        <dd>
+          The touched state of the button. This property MUST be true if the
+          button is capable of detecting touch and is currently touched. If the
+          button is not capable of detecting touch or is not currently touched
+          this property MUST be false.
+        </dd>
+
         <dt>readonly attribute double value</dt>
         <dd>
           For buttons that have an analog sensor, this property


### PR DESCRIPTION
This is my proposal for adding explicit touchpad support to the Gamepad spec. Seems like creating a pull request here may be a more productive way to fostering conversation around the feature than the mailing list, which was relatively quiet on the subject.

It seems to me that effective touchpad support should only require this single new attribute. Touchpad position can accurately be represented by the existing `axes` array, but developers will need to be able to disambiguate between `[0, 0]` being a centered touch or no touch at all. That can be handled via the existing `pressed` value in a button, but it's awkward both in name and use. Many touchpads are clickable, meaning that the single control may have both a touched an a pressed state. Having a touched and a pressed state on a single button allows us to track both states while logically associating them with a single physical control. Furthermore some touchpads are pressure sensitive, but it's hard to imagine that such a control would also have separate tracking for clicked pressure, so the single existing `value` attribute should cover both touch pressure and button pressed amount.

There is also some upcoming hardware ([Oculus Touch](https://www.oculus.com/en-us/touch/)) for which many of the physical buttons will also have capacitive touch tracking to determine the position of the fingers. Adding a `touched` property to the buttons serves that case well.

There still exists some ambiguity over which button is associated with which axes, but that's a pre-existing problem and this addition doesn't make it any worse. This also ignores multi-touch surfaces (The PS4 controller has one) but considering the large amount of effort that has gone into supporting multi-touch for mobile devices it seems like that's not something we want to duplicate into the gamepad API.
