### PR TITLE
Added a supplemental "Extensions" spec

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -175,31 +175,55 @@
     <section>
       <h2><dfn>GamepadHaptic</dfn> Interface</h2>
       <p>
-        This interface defines a haptic feedback motor on the gamepad, and
-        enables activating it.
+        Each <code>GamepadHapticActuator</code> corresponds to a motor or other
+        actuator that can apply a force for the purposes of haptic feedback.
       </p>
 
       <pre class='idl'>
-      interface GamepadHaptic {
-        boolean vibrate(double intensity, double duration);
+      interface GamepadHapticActuator {
+        readonly attribute GamepadHapticActuatorType type;
+        Promise<void> pulse(double value, double duration);
       };
       </pre>
 
-      <dl data-dfn-for="GamepadHaptic">
-        <dt><dfn data-lt="vibrate()">vibrate</dfn></dt>
+      <dl data-dfn-for="GamepadHapticActuator">
+        <dt><dfn data-lt="pulse()">pulse</dfn></dt>
         <dd>
           <p>
-          The <code>vibrate()</code> method engages the haptic
-          feedback motor for <var>duration</var> milliseconds.
+          <code>pulse()</code> applies a value to the actuator for
+          <var>duration</var> milliseconds. The value passed to
+          <code>pulse()</code> is clamped to limits defined by the actuator
+          type. The returned promise will resolve true once the pulse has
+          completed.
           </p>
           <p>
-          If the haptic feedback motor is capable of modulating the intensity of
-          its feedback, it should scale its output by <var>intensity</var>,
-          clamped to a [0, 1] range with 0 being no output and 1 being full
-          output. If the haptic feedback motor is not capable of modulating the
-          intensity of its feedback, it should provide its default output if
-          any non-zero <var>intensity</var> is specified.
+          Repeated calls to <code>pulse()</code> override the previous values.
           </p>
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadHapticActuatorType</dfn> Enum</h2>
+      <p>
+        The actuator type determines the force applied for a given "value" in
+        GamepadHapticActuator.pulse()
+      </p>
+
+      <pre class="idl">
+        enum GamepadHapticActuatorType {
+            "vibration"
+        };
+      </pre>
+
+      <dl data-dfn-for="GamepadHapticActuatorType">
+        <dt></dt>
+        <dt><dfn>vibration</dfn></dt>
+        <dd>
+          Vibration is a rumbling effect often implemented as an offset weight
+          driven on a rotational axis. The <code>value</code> of a vibration
+          force determines the frequency of the rumble effect and is normalized
+          between 0.0 and 1.0. The neutral value is 0.0.
         </dd>
       </dl>
     </section>
@@ -311,7 +335,7 @@
       <pre class='idl'>
       partial interface Gamepad {
         readonly attribute GamepadHand hand;
-        readonly attribute GamepadHaptic[] haptics;
+        readonly attribute GamepadHapticActuator[] hapticActuators;
         readonly attribute GamepadPose? pose;
       };
       </pre>
@@ -323,9 +347,9 @@
           to be held in.
         </dd>
 
-        <dt><dfn>haptics</dfn></dt>
+        <dt><dfn>hapticActuators</dfn></dt>
         <dd>
-          A list of all the haptic feedback motors in the gamepad.
+          A list of all the haptic actuators in the gamepad.
         </dd>
 
         <dt><dfn>pose</dfn></dt>

--- a/extensions.html
+++ b/extensions.html
@@ -52,7 +52,7 @@
             key: 'Repository and Participation',
             data: [
                 {
-                    value: 'We are on github.',
+                    value: 'We are on GitHub.',
                     href: 'https://github.com/w3c/gamepad/'
                 }, {
                     value: 'File a bug/issue.',
@@ -116,7 +116,7 @@
       If you have comments for this spec, please send them to
       <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a>
       with a Subject: prefix of <code>[gamepad]</code>. See
-      <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&component=Gamepad&resolution=---">Bugzilla</a>
+      <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=Gamepad&amp;resolution=---">Bugzilla</a>
       for this specification's open bugs.
     </section>
 
@@ -125,16 +125,16 @@
       <h2>Introduction</h2>
 
       <p>The Gamepad API provides a tightly scoped interface to gamepad devices
-      that's focused on the most common elements of those devices. Namely: Axis
+      that's focused on the most common elements of those devices, namely: Axis
       and button input. It specifically excludes support for more complex
-      devices that may also such as those that that do motion sensing or
+      devices that may also such as those that that do motion tracking or
       haptic feedback.</p>
 
-      <p>However some uses of gamepads, such as those paired with Virtual
-      Reality headsets, rely heavily on those more advanced features. This
-      supplemetary spec describes extensions to the base API to accomodate those
-      use cases. If they prove to be broadly useful the hope is that they will
-      be eventually merged into the main spec.</p>
+      <p>However, some uses of gamepads (such as those paired with Virtual
+      Reality headsets) rely heavily on those more advanced features. This
+      supplemetary spec describes extensions to the base API to accommodate
+      those use cases. If they prove to be broadly useful, the hope is that they
+      will be eventually merged into the main spec.</p>
 
     </section>
 
@@ -155,8 +155,9 @@
       <dl data-dfn-for="GamepadHand">
         <dt></dt>
         <dd>
-          The empty string indicates the hand holding the gamepad is unknown or
-          not applicable (for example, if the gamepad is held with two hands.)
+          The empty string indicates the hand that is holding the gamepad is
+          unknown or not applicable. (For example, if the gamepad is held with
+          two hands.)
         </dd>
 
         <dt><dfn>left</dfn></dt>
@@ -187,15 +188,18 @@
       <dl data-dfn-for="GamepadHaptic">
         <dt><dfn data-lt="vibrate()">vibrate</dfn></dt>
         <dd>
+          <p>
           The <code>vibrate()</code> method engages the haptic
           feedback motor for <var>duration</var> milliseconds.
-
-          If the haptic feedback motor is capable of modulating the intensity of it's
-          feedback, it should scale it's output by <var>intensity</var>,
+          </p>
+          <p>
+          If the haptic feedback motor is capable of modulating the intensity of
+          its feedback, it should scale its output by <var>intensity</var>,
           clamped to a [0, 1] range with 0 being no output and 1 being full
           output. If the haptic feedback motor is not capable of modulating the
-          intensity of it's feedback it should provide it's default output if any
-          non-zero <var>intensity</var> is specified.
+          intensity of its feedback, it should provide its default output if
+          any non-zero <var>intensity</var> is specified.
+          </p>
         </dd>
       </dl>
     </section>
@@ -236,12 +240,14 @@
 
         <dt><dfn>position</dfn></dt>
         <dd>
+          <p>
           Position of the gamepad as a 3D vector. Position is given in meters
           from an origin point, which is determined by the gamepad hardware, and
-          may be the position of the gamepad when first polled if no other
+          MAY be the position of the gamepad when first polled if no other
           reference point is available. The coordinate system uses these axis
           definitions, assuming the user is holding the gamepad in the forward
           orientation:
+          </p>
 
           <ul>
             <li>Positive X is to the user's right.</li>
@@ -249,8 +255,10 @@
             <li>Positive Z is behind the user.</li>
           </ul>
 
+          <p>
           MUST be null if the gamepad is incapable of providing positional data.
           When not null MUST be a three-element array.
+          </p>
         </dd>
 
         <dt><dfn>linearVelocity</dfn></dt>

--- a/extensions.html
+++ b/extensions.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Gamepad Extensions</title>
+    <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+    <meta name="viewport" content="width=device-width">
+    <!--
+      === NOTA BENE ===
+      For the three scripts below, if your spec resides on dev.w3 you can check them
+      out in the same tree and use relative links so that they'll work offline,
+     -->
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script class='remove'>
+      var respecConfig = {
+          // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+          specStatus:           "ED",
+
+          // the specification's short name, as in http://www.w3.org/TR/short-name/
+          shortName:            "gamepad-extensions",
+
+          // if your specification has a subtitle that goes below the main
+          // formal title, define it here
+          // subtitle   :  "an excellent document",
+
+          // if you wish the publication date to be other than today, set this
+          //publishDate:  "2011-01-01",
+
+          // if the specification's copyright date is a range of years, specify
+          // the start date here:
+          // copyrightStart: "2005"
+
+          // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+          // and its maturity status
+
+          processVersion: "2015",
+
+          // if there a publicly available Editor's Draft, this is the link
+          edDraftURI:   "https://w3c.github.io/gamepad/extensions.html",
+
+          // if this is a LCWD, uncomment and set the end of its review period
+          // lcEnd: "2009-08-05",
+
+          // editors, add as many as you like
+          // only "name" is required
+          editors:  [
+              { name: "Brandon Jones", url: "http://tojicode.com/",
+                company: "Google", companyURL: "http://www.google.com/",
+                w3cid: 87824 },
+          ],
+
+          otherLinks: [{
+            key: 'Repository and Participation',
+            data: [
+                {
+                    value: 'We are on github.',
+                    href: 'https://github.com/w3c/gamepad/'
+                }, {
+                    value: 'File a bug/issue.',
+                    href: 'https://github.com/w3c/gamepad/issues'
+                }, {
+                    value: 'Commit history.',
+                    href: 'https://github.com/w3c/gamepad/commits'
+                }, {
+                    value: 'Mailing list search.',
+                    href: 'https://www.w3.org/Search/Mail/Public/search?keywords=&hdr-1-name=subject&hdr-1-query=gamepad&index-grp=Public_FULL&index-type=t&type-index=public-webapps'
+                }
+             ]
+          }],
+
+          // authors, add as many as you like.
+          // This is optional, uncomment if you have authors as well as editors.
+          // only "name" is required. Same format as editors.
+
+          //authors:  [
+          //    { name: "Your Name", url: "http://example.org/",
+          //      company: "Your Company", companyURL: "http://example.com/" },
+          //],
+
+          // name of the WG
+          wg:           "Web Platform Working Group",
+
+          // URI of the public WG page
+          wgURI:        "http://www.w3.org/WebPlatform/WG/",
+          license:	"w3c-software-doc",
+
+          // name (with the @w3c.org) of the public mailing to which comments are due
+          wgPublicList: "public-webapps",
+
+          // URI of the patent status for this WG, for Rec-track documents
+          // !!!! IMPORTANT !!!!
+          // This is important for Rec-track documents, do not copy a patent URI from a random
+          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+          // Team Contact.
+          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/83482/status",
+      };
+    </script>
+
+    <style type="text/css">
+      .event {
+        font-family: monospace;
+        color: #459900;
+      }
+
+      pre.idl {
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <section id='abstract'>
+      Extensions to the base Gamepad specification to enable a access to more
+      advanced device capabilities.
+    </section>
+
+    <section id='sotd'>
+      If you have comments for this spec, please send them to
+      <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a>
+      with a Subject: prefix of <code>[gamepad]</code>. See
+      <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&component=Gamepad&resolution=---">Bugzilla</a>
+      for this specification's open bugs.
+    </section>
+
+    <section id='introduction' class='informative'>
+
+      <h2>Introduction</h2>
+
+      <p>The Gamepad API provides a tightly scoped interface to gamepad devices
+      that's focused on the most common elements of those devices. Namely: Axis
+      and button input. It specifically excludes support for more complex
+      devices that may also such as those that that do motion sensing or
+      haptic feedback.</p>
+
+      <p>However some uses of gamepads, such as those paired with Virtual
+      Reality headsets, rely heavily on those more advanced features. This
+      supplemetary spec describes extensions to the base API to accomodate those
+      use cases. If they prove to be broadly useful the hope is that they will
+      be eventually merged into the main spec.</p>
+
+    </section>
+
+    <section>
+      <h2><dfn>GamepadHand</dfn> Enum</h2>
+      <p>
+        This enum defines the set of possible hands a gamepad may be held by.
+      </p>
+
+      <pre class="idl">
+        enum GamepadHand {
+            "",
+            "left",
+            "right"
+        };
+      </pre>
+
+      <dl data-dfn-for="GamepadHand">
+        <dt></dt>
+        <dd>
+          The empty string indicates the hand holding the gamepad is unknown or
+          not applicable (for example, if the gamepad is held with two hands.)
+        </dd>
+
+        <dt><dfn>left</dfn></dt>
+        <dd>
+          Gamepad is held or is most likely to be held in the left hand.
+        </dd>
+
+        <dt><dfn>right</dfn></dt>
+        <dd>
+          Gamepad is held or is most likely to be held in the right hand.
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadHaptic</dfn> Interface</h2>
+      <p>
+        This interface defines a haptic feedback motor on the gamepad, and
+        enables activating it.
+      </p>
+
+      <pre class='idl'>
+      interface GamepadHaptic {
+        boolean vibrate(double intensity, double duration);
+      };
+      </pre>
+
+      <dl data-dfn-for="GamepadHaptic">
+        <dt><dfn data-lt="vibrate()">vibrate</dfn></dt>
+        <dd>
+          The <code>vibrate()</code> method engages the haptic
+          feedback motor for <var>duration</var> milliseconds.
+
+          If the haptic feedback motor is capable of modulating the intensity of it's
+          feedback, it should scale it's output by <var>intensity</var>,
+          clamped to a [0, 1] range with 0 being no output and 1 being full
+          output. If the haptic feedback motor is not capable of modulating the
+          intensity of it's feedback it should provide it's default output if any
+          non-zero <var>intensity</var> is specified.
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadPose</dfn> Interface</h2>
+      <p>
+        This interface defines the gamepad's position, orientation, velocity,
+        and acceleration.
+      </p>
+
+      <pre class='idl'>
+      interface GamepadPose {
+        readonly attribute boolean hasOrientation;
+        readonly attribute boolean hasPosition;
+
+        readonly attribute Float32Array? position;
+        readonly attribute Float32Array? linearVelocity;
+        readonly attribute Float32Array? linearAcceleration;
+        readonly attribute Float32Array? orientation;
+        readonly attribute Float32Array? angularVelocity;
+        readonly attribute Float32Array? angularAcceleration;
+      };
+      </pre>
+
+      <dl data-dfn-for="GamepadPose">
+        <dt><dfn>hasOrientation</dfn></dt>
+        <dd>
+          The hasOrientation attribute MUST return whether the gamepad is
+          capable of tracking its orientation.
+        </dd>
+
+        <dt><dfn>hasPosition</dfn></dt>
+        <dd>
+          The hasPosition attribute MUST return whether the gamepad is capable
+          of tracking its position.
+        </dd>
+
+        <dt><dfn>position</dfn></dt>
+        <dd>
+          Position of the gamepad as a 3D vector. Position is given in meters
+          from an origin point, which is determined by the gamepad hardware, and
+          may be the position of the gamepad when first polled if no other
+          reference point is available. The coordinate system uses these axis
+          definitions, assuming the user is holding the gamepad in the forward
+          orientation:
+
+          <ul>
+            <li>Positive X is to the user's right.</li>
+            <li>Positive Y is up.</li>
+            <li>Positive Z is behind the user.</li>
+          </ul>
+
+          MUST be null if the gamepad is incapable of providing positional data.
+          When not null MUST be a three-element array.
+        </dd>
+
+        <dt><dfn>linearVelocity</dfn></dt>
+        <dd>
+          Linear velocity of the gamepad in meters per second. MUST be null if
+          the sensor is incapable of providing linear velocity. When not null
+          MUST be a three-element array.
+        </dd>
+
+        <dt><dfn>linearAcceleration</dfn></dt>
+        <dd>
+          Linear acceleration of the gamepad in meters per second. MUST be null
+          if the sensor is incapable of providing linear acceleration. When not
+          null MUST be a three-element array.
+        </dd>
+
+        <dt><dfn>orientation</dfn></dt>
+        <dd>
+          Orientation of the gamepad as a quaternion. An orientation of
+          [0, 0, 0, 1] is considered to be "forward". The forward direction is
+          determined by the gamepad hardware, and may be the orientation of the
+          hardware when it was first polled if no other reference orientation is
+          available. MUST be null if the sensor is incapable of providing
+          orientation data. When not null MUST be a four-element array.
+        </dd>
+
+        <dt><dfn>angularVelocity</dfn></dt>
+        <dd>
+          Angular velocity of the gamepad in meters per second. MUST be null if
+          the sensor is incapable of providing angular velocity. When not null
+          MUST be a three-element array.
+        </dd>
+
+        <dt><dfn>angularAcceleration</dfn></dt>
+        <dd>
+          Angular acceleration of the gamepad in meters per second. MUST be null
+          if the sensor is incapable of providing angular acceleration. When not
+          null MUST be a three-element array.
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2>Partial <dfn>Gamepad</dfn> Interface</h2>
+      <p>
+        This partial interface supplements the Gamepad interface described in
+        the main <a href="https://w3c.github.io/gamepad/">Gamepad spec</a>.
+      </p>
+
+      <pre class='idl'>
+      partial interface Gamepad {
+        readonly attribute GamepadHand hand;
+        readonly attribute GamepadHaptic[] haptics;
+        readonly attribute GamepadPose? pose;
+      };
+      </pre>
+
+      <dl data-dfn-for="Gamepad">
+        <dt><dfn>hand</dfn></dt>
+        <dd>
+          Describes the hand the controller is held in, or most likely
+          to be held in.
+        </dd>
+
+        <dt><dfn>haptics</dfn></dt>
+        <dd>
+          A list of all the haptic feedback motors in the gamepad.
+        </dd>
+
+        <dt><dfn>pose</dfn></dt>
+        <dd>
+          The current pose of the gamepad, if supported by the hardware.
+          Includes position, orientation, velocity, and acceleration. If the
+          hardware cannot supply any pose values MUST be set to null.
+        </dd>
+      </dl>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
This is to provide a place to maintain the specs for the proposed additions to the Gamepad API for reference, discussion, and bug fixing while the main spec is in the process of progressing to a CR.

This is maybe a bit unorthodox, but while I understand the desire to not push a bunch of new changes into the spec before it progresses to CR the lack of a formal spec for these proposals is turning into a blocker for me. Hopefully this strikes a happy balance that allows those who are interested to reference this spec when needed and have discussions around the features it contains while those who are only interested in the main spec can blissfully ignore it.
