### PR TITLE
Fix GamepadPose units, align with VRPose

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -294,9 +294,9 @@
 
         <dt><dfn>linearAcceleration</dfn></dt>
         <dd>
-          Linear acceleration of the gamepad in meters per second. MUST be null
-          if the sensor is incapable of providing linear acceleration. When not
-          null MUST be a three-element array.
+          Linear acceleration of the gamepad in meters per second squared. MUST
+          be null if the sensor is incapable of providing linear acceleration.
+          When not null MUST be a three-element array.
         </dd>
 
         <dt><dfn>orientation</dfn></dt>
@@ -311,16 +311,16 @@
 
         <dt><dfn>angularVelocity</dfn></dt>
         <dd>
-          Angular velocity of the gamepad in meters per second. MUST be null if
-          the sensor is incapable of providing angular velocity. When not null
-          MUST be a three-element array.
+          Angular velocity of the gamepad in radians per second. MUST be null
+          if the sensor is incapable of providing angular velocity. When not
+          null MUST be a three-element array.
         </dd>
 
         <dt><dfn>angularAcceleration</dfn></dt>
         <dd>
-          Angular acceleration of the gamepad in meters per second. MUST be null
-          if the sensor is incapable of providing angular acceleration. When not
-          null MUST be a three-element array.
+          Angular acceleration of the gamepad in radians per second squared.
+          MUST be null if the sensor is incapable of providing angular
+          acceleration. When not null MUST be a three-element array.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
See [`GamepadPose`](https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose) vs. [`VRPose`](https://w3c.github.io/webvr/#vrpose).

@toji PTAL.
