### PR TITLE
Add missing type argument to the GamepadEvent constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,9 +463,9 @@
     <section data-dfn-for="GamepadEvent">
       <h2><dfn>GamepadEvent</dfn> Interface</h2>
       <pre class="idl">
-        [Constructor(GamepadEventInit eventInitDict)]
+        [Constructor(DOMString type, GamepadEventInit eventInitDict)]
         interface GamepadEvent: Event {
-          readonly attribute Gamepad gamepad;
+          [SameObject] readonly attribute Gamepad gamepad;
         };
       </pre>
       <dl>


### PR DESCRIPTION
Fixes #35.

Also add [SameObject] while in the area, since event.gamepad can't change.