### PR TITLE
Switch from WebIDL arrays to FrozenArray<>s in the IDLs.

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -341,7 +341,7 @@
       <pre class="idl">
         partial interface Gamepad {
           readonly attribute GamepadHand hand;
-          readonly attribute GamepadHapticActuator[] hapticActuators;
+          readonly attribute FrozenArray&lt;GamepadHapticActuator> hapticActuators;
           readonly attribute GamepadPose? pose;
         };
       </pre>
@@ -355,7 +355,9 @@
 
         <dt><dfn>hapticActuators</dfn></dt>
         <dd>
-          A list of all the haptic actuators in the gamepad.
+          A list of all the haptic actuators in the gamepad. The same object
+          MUST be returned until the user agent needs to return different
+          values (or values in a different order).
         </dd>
 
         <dt><dfn>pose</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -222,8 +222,8 @@
           readonly attribute boolean connected;
           readonly attribute DOMHighResTimeStamp timestamp;
           readonly attribute GamepadMappingType mapping;
-          readonly attribute double[] axes;
-          readonly attribute GamepadButton[] buttons;
+          readonly attribute FrozenArray&lt;double> axes;
+          readonly attribute FrozenArray&lt;GamepadButton> buttons;
         };
       </pre>
       <dl>
@@ -311,6 +311,9 @@
           importance, such that element 0 and 1 typically represent the X and
           Y axis of a directional stick.
 
+          The same object MUST be returned until the <a>user agent</a> needs to
+          return different values (or values in a different order).
+
         </dd>
 
         <dt><dfn>buttons</dfn></dt>
@@ -320,6 +323,9 @@
           It is RECOMMENDED that buttons appear in decreasing importance such
           that the primary button, secondary button, tertiary button, and so
           on appear as elements 0, 1, 2, ... in the buttons array.
+
+          The same object MUST be returned until the <a>user agent</a> needs to
+          return different values (or values in a different order).
 
         </dd>
 


### PR DESCRIPTION
Arrays have not existed in the WebIDL spec since 2015, so the Gamepad
spec (as well as the accompanying Gamepad Extensions one) were providing
invalid IDL definitions.

Switch to FrozenArray<T> and clarify in prose that some attributes should be
cached by the user agent until new values have to be returned.

Fixes #28.