### PR TITLE
spec vibrationActuator gamepad extension

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -195,36 +195,74 @@
         <dt><dfn data-lt="playEffect()">playEffect</dfn></dt>
         <dd>
           <p>
-            <code>playEffect()</code> interprets the effect parameters in
-            <var>params</var> as a haptic effect with the specified
-            <var>type</var> and issues it to the gamepad. It returns a
-            Promise that resolves to <code>'complete'</code> once the effect
-            is complete.
+            The <code>playEffect(type, params)</code> method, when invoked, must return
+            a new promise <var>promise</var> and run the following steps in
+            parallel:
           </p>
           <p>
-            If the effect parameters are invalid, <code>playEffect()</code>
-            must return with a Promise resolved to
-            <code>'invalid-parameter'</code>. The validity of the effect
-            parameters is defined by the effect type.
+            1. Validate that the effect parameters in <var>params</var>
+            describe a valid effect of type <var>type</var>. The validity
+            may depend on the type of effect specified. If the effect is
+            invalid, resolve <var>promise</var> with <var>'invalid-parameter'</var>
+            and abort these steps.
           </p>
           <p>
-            If the effect type is not compatible with the actuator,
-            the Promise returned by <code>playEffect()</code> must be resolved
-            to <code>'not-supported'</code>.
+            2. If the current page is not visible, resolve <var>promise</var> with
+            <var>'preempted'</var> and abort these steps.
           </p>
           <p>
-            Repeated calls to <code>playEffect()</code> preempt previous calls.
-            If an effect is preempted, it must resolve its Promise to
-            <code>'preempted'</code> before the new effect is started.
+            3. If the vibration actuator is already playing an effect, resolve the
+            <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+          </p>
+          <p>
+            4. If the effect type is not compatible with the haptic actuator type,
+            resolve <var>promise</var> with <var>'not-supported'</var> and abort
+            these steps.
+          </p>
+          <p>
+            5. Issue the haptic effect to the actuator.
+          </p>
+          <p>
+            6. After the effect is complete, resolve <var>promise</var> to
+            <var>'complete'</var>.
           </p>
         </dd>
 
         <dt><dfn data-lt="reset()">reset</dfn></dt>
         <dd>
           <p>
-            <code>reset()</code> stops haptic feedback and preempts any active
-            effects. It returns a Promise that resolves to
-            <code>'complete'</code> once vibration is stopped.
+            The <code>reset()</code> method, when invoked, must return
+            a new promise <var>promise</var> and run the following steps in
+            parallel:
+          </p>
+          <p>
+            1. If the current page is not visible, resolve <var>promise</var> with
+            <var>'preempted'</var> and abort these steps.
+          </p>
+          <p>
+            2. If the vibration actuator is playing an effect, resolve the
+            <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+          </p>
+          <p>
+            3. Issue the reset command to the actuator to stop vibration.
+          </p>
+          <p>
+            4. Once vibration is stopped, resolve <var>promise</var> to
+            <var>'complete'</var>.
+          </p>
+        </dd>
+
+        <dt>Page visibility</dt>
+        <dd>
+          <p>
+            If page visibility is lost while an effect is playing, execute
+            these steps:
+          </p>
+          <p>
+            1. Resolve <var>promise</var> with <var>'preempted'</var>.
+          </p>
+          <p>
+            2. Issue the reset command to the actuator to stop vibration.
           </p>
         </dd>
       </dl>
@@ -274,19 +312,34 @@
       <dl data-dfn-for="GamepadHapticEffectType">
         <dt><dfn>dual-rumble</dfn></dt>
         <dd>
+        <p>
           A dual-rumble effect is a fixed-length, constant-intensity vibration
           effect intended for an actuator of type <code>'dual-rumble'</code>.
           Dual-rumble effects are defined by four parameters.
+        </p>
+        <p>
           <var>duration</var> sets the duration of the vibration effect in
-          milliseconds, default 0. <var>startDelay</var> sets the duration of
-          the delay after <code>playEffect()</code> is called until vibration
+          milliseconds, default 0. A negative <var>duration</var> is considered
+          invalid.
+        </p>
+        <p>
+          <var>startDelay</var> sets the duration of the delay after
+          <code>playEffect()</code> is called until vibration
           is started, default 0. During the delay interval, the actuator must
-          not vibrate. To prevent abuse, the user agent should consider an
+          not vibrate. A negative <var>startDelay</var> is considered invalid.
+        </p>
+        <p>
+          To prevent abuse, the user agent may consider an
           effect invalid if the total effect duration (the sum of the vibration
-          interval and delay interval) exceeds some reasonable value, say 5
-          seconds. <var>strongMagnitude</var> and <var>weakMagnitude</var> set
+          interval and delay interval) exceeds some maximum duration.
+          A maximum of 5 seconds is recommended.
+        </p>
+        <p>
+          <var>strongMagnitude</var> and <var>weakMagnitude</var> set
           the vibration intensity levels for the heavier and lighter ERM
           motors, normalized to the range <code>[0,1]</code>, default 0.
+          Values outside of this range are invalid.
+        </p>
         </dd>
       </dl>
     </section>

--- a/extensions.html
+++ b/extensions.html
@@ -161,7 +161,7 @@
           two hands).
         </dd>
 
-        <dt>"<dfn>left</dfn>"</dt>
+        <dt><dfn>left</dfn></dt>
         <dd>
           Gamepad is held or is most likely to be held in the left hand.
         </dd>
@@ -183,7 +183,7 @@
 
       <pre class="idl">
         interface GamepadHapticActuator {
-          readonly attribute GamepadHapticActuatorType type;
+          boolean canPlayEffectType(GamepadHapticEffectType type);
           Promise<GamepadHapticsResult> playEffect(
               GamepadHapticEffectType type,
               GamepadEffectParameters params);
@@ -192,30 +192,40 @@
       </pre>
 
       <dl data-dfn-for="GamepadHapticActuator">
+        <dt><dfn data-lt="canPlayEffectType()">canPlayEffectType</dfn></dt>
+        <dd>
+          <p>
+            The <code>canPlayEffectType(type)</code> method, when invoked, must
+            return true if this actuator is capable of playing effects with the
+            specified type.
+          </p>
+        </dd>
+
         <dt><dfn data-lt="playEffect()">playEffect</dfn></dt>
         <dd>
           <p>
-            The <code>playEffect(type, params)</code> method, when invoked, must return
-            a new Promise <var>promise</var> and run the following steps in
-            parallel:
+            The <code>playEffect(type, params)</code> method, when invoked,
+            must return a new Promise <var>promise</var> and run the following
+            steps in parallel:
           </p>
           <ol>
             <li>
               Validate that the effect parameters in <var>params</var>
               describe a valid effect of type <var>type</var>. The validity
               may depend on the type of effect specified. If the effect is
-              invalid, resolve <var>promise</var> with <var>'invalid-parameter'</var>
-              and abort these steps.
+              invalid, resolve <var>promise</var> with
+              <var>'invalid-parameter'</var> and abort these steps.
             <li>
-              If the current page is not visible, resolve <var>promise</var> with
-              <var>'preempted'</var> and abort these steps.
+              If the current page is not visible, resolve <var>promise</var>
+              with <var>'preempted'</var> and abort these steps.
             <li>
-              If the vibration actuator is already playing an effect, resolve the
-              <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+              If the vibration actuator is already playing an effect, resolve
+              the <var>promise</var> for the ongoing effect to
+              <var>'preempted'</var>.
             <li>
-              If the effect type is not compatible with the haptic actuator type,
-              resolve <var>promise</var> with <var>'not-supported'</var> and abort
-              these steps.
+              If the effect type is not compatible with the haptic actuator,
+              resolve <var>promise</var> with <var>'not-supported'</var> and
+              abort these steps.
             <li>
               Issue the haptic effect to the actuator.
             <li>
@@ -233,11 +243,12 @@
           </p>
           <ol>
             <li>
-              If the current page is not visible, resolve <var>promise</var> with
-              <var>'preempted'</var> and abort these steps.
+              If the current page is not visible, resolve <var>promise</var>
+              with <var>'preempted'</var> and abort these steps.
             <li>
               If the vibration actuator is playing an effect, resolve the
-              <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+              <var>promise</var> for the ongoing effect to
+              <var>'preempted'</var>.
             <li>
               Issue the reset command to the actuator to stop vibration.
             <li>
@@ -263,34 +274,6 @@
     </section>
 
     <section>
-      <h2><dfn>GamepadHapticActuatorType</dfn> Enum</h2>
-      <p>
-        The actuator type describes the capabilities of the gamepad's
-        haptics configuration.
-      </p>
-
-      <pre class="idl">
-        enum GamepadHapticActuatorType {
-          "dual-rumble"
-        };
-      </pre>
-
-      <dl data-dfn-for="GamepadHapticActuatorType">
-        <dt><dfn>dual-rumble</dfn></dt>
-        <dd>
-          Dual-rumble describes a haptics configuration with an eccentric
-          rotating mass (ERM) vibration motor in each handle of a standard
-          gamepad. In this configuration, either motor is capable of vibrating
-          the whole gamepad. The ERM masses are unequal so that the effects of
-          each can be combined to create more complex haptic effects. A device
-          may expose a vibration actuator with type <code>'dual-rumble'</code>
-          if it has a dual-ERM configuration, or if it has an alternate haptics
-          configuration that is compatible with dual-rumble effects.
-        </dd>
-      </dl>
-    </section>
-
-    <section>
       <h2><dfn>GamepadHapticEffectType</dfn> Enum</h2>
       <p>
         The effect type defines how the effect parameters are interpreted by
@@ -307,10 +290,17 @@
         <dt><dfn>dual-rumble</dfn></dt>
         <dd>
           <p>
+            Dual-rumble describes a haptics configuration with an eccentric
+            rotating mass (ERM) vibration motor in each handle of a standard
+            gamepad. In this configuration, either motor is capable of
+            vibrating the whole gamepad. The ERM masses are unequal so that the
+            effects of each can be combined to create more complex haptic
+            effects.
+          </p>
+          <p>
             A dual-rumble effect is a fixed-length, constant-intensity
-            vibration effect intended for an actuator of type
-            <code>'dual-rumble'</code>. Dual-rumble effects are defined by four
-            parameters.
+            vibration effect intended for an actuator of this type. Dual-rumble
+            effects are defined by four parameters.
           </p>
           <p>
             <var>duration</var> sets the duration of the vibration effect in

--- a/extensions.html
+++ b/extensions.html
@@ -196,7 +196,7 @@
         <dd>
           <p>
             The <code>playEffect(type, params)</code> method, when invoked, must return
-            a new promise <var>promise</var> and run the following steps in
+            a new Promise <var>promise</var> and run the following steps in
             parallel:
           </p>
           <p>
@@ -232,7 +232,7 @@
         <dd>
           <p>
             The <code>reset()</code> method, when invoked, must return
-            a new promise <var>promise</var> and run the following steps in
+            a new Promise <var>promise</var> and run the following steps in
             parallel:
           </p>
           <p>

--- a/extensions.html
+++ b/extensions.html
@@ -209,7 +209,7 @@
           </p>
           <p>
             If the effect type is not compatible with the actuator,
-            <code>playEffect()</code> must immediately return a Promise resolved
+            the Promise returned by <code>playEffect()</code> must be resolved
             to <code>'not-supported'</code>.
           </p>
           <p>

--- a/extensions.html
+++ b/extensions.html
@@ -47,7 +47,7 @@
                 company: "Google", companyURL: "http://www.google.com/",
                 w3cid: 87824 },
               { name: "Matt Reynolds", company: "Google",
-                companyURL: "http://www.google.com/"}
+                companyURL: "http://www.google.com/", w3cid: 105511 }
           ],
 
           otherLinks: [{

--- a/extensions.html
+++ b/extensions.html
@@ -199,33 +199,29 @@
             a new Promise <var>promise</var> and run the following steps in
             parallel:
           </p>
-          <p>
-            1. Validate that the effect parameters in <var>params</var>
-            describe a valid effect of type <var>type</var>. The validity
-            may depend on the type of effect specified. If the effect is
-            invalid, resolve <var>promise</var> with <var>'invalid-parameter'</var>
-            and abort these steps.
-          </p>
-          <p>
-            2. If the current page is not visible, resolve <var>promise</var> with
-            <var>'preempted'</var> and abort these steps.
-          </p>
-          <p>
-            3. If the vibration actuator is already playing an effect, resolve the
-            <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
-          </p>
-          <p>
-            4. If the effect type is not compatible with the haptic actuator type,
-            resolve <var>promise</var> with <var>'not-supported'</var> and abort
-            these steps.
-          </p>
-          <p>
-            5. Issue the haptic effect to the actuator.
-          </p>
-          <p>
-            6. After the effect is complete, resolve <var>promise</var> to
-            <var>'complete'</var>.
-          </p>
+          <ol>
+            <li>
+              Validate that the effect parameters in <var>params</var>
+              describe a valid effect of type <var>type</var>. The validity
+              may depend on the type of effect specified. If the effect is
+              invalid, resolve <var>promise</var> with <var>'invalid-parameter'</var>
+              and abort these steps.
+            <li>
+              If the current page is not visible, resolve <var>promise</var> with
+              <var>'preempted'</var> and abort these steps.
+            <li>
+              If the vibration actuator is already playing an effect, resolve the
+              <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+            <li>
+              If the effect type is not compatible with the haptic actuator type,
+              resolve <var>promise</var> with <var>'not-supported'</var> and abort
+              these steps.
+            <li>
+              Issue the haptic effect to the actuator.
+            <li>
+              After the effect is complete, resolve <var>promise</var> to
+              <var>'complete'</var>.
+          </ol>
         </dd>
 
         <dt><dfn data-lt="reset()">reset</dfn></dt>
@@ -235,21 +231,19 @@
             a new Promise <var>promise</var> and run the following steps in
             parallel:
           </p>
-          <p>
-            1. If the current page is not visible, resolve <var>promise</var> with
-            <var>'preempted'</var> and abort these steps.
-          </p>
-          <p>
-            2. If the vibration actuator is playing an effect, resolve the
-            <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
-          </p>
-          <p>
-            3. Issue the reset command to the actuator to stop vibration.
-          </p>
-          <p>
-            4. Once vibration is stopped, resolve <var>promise</var> to
-            <var>'complete'</var>.
-          </p>
+          <ol>
+            <li>
+              If the current page is not visible, resolve <var>promise</var> with
+              <var>'preempted'</var> and abort these steps.
+            <li>
+              If the vibration actuator is playing an effect, resolve the
+              <var>promise</var> for the ongoing effect to <var>'preempted'</var>.
+            <li>
+              Issue the reset command to the actuator to stop vibration.
+            <li>
+              Once vibration is stopped, resolve <var>promise</var> to
+              <var>'complete'</var>.
+          </ol>
         </dd>
 
         <dt>Page visibility</dt>
@@ -258,12 +252,12 @@
             If page visibility is lost while an effect is playing, execute
             these steps:
           </p>
-          <p>
-            1. Resolve <var>promise</var> with <var>'preempted'</var>.
-          </p>
-          <p>
-            2. Issue the reset command to the actuator to stop vibration.
-          </p>
+          <ol>
+            <li>
+              Resolve <var>promise</var> with <var>'preempted'</var>.
+            <li>
+              Issue the reset command to the actuator to stop vibration.
+          </ol>
         </dd>
       </dl>
     </section>

--- a/extensions.html
+++ b/extensions.html
@@ -306,34 +306,36 @@
       <dl data-dfn-for="GamepadHapticEffectType">
         <dt><dfn>dual-rumble</dfn></dt>
         <dd>
-        <p>
-          A dual-rumble effect is a fixed-length, constant-intensity vibration
-          effect intended for an actuator of type <code>'dual-rumble'</code>.
-          Dual-rumble effects are defined by four parameters.
-        </p>
-        <p>
-          <var>duration</var> sets the duration of the vibration effect in
-          milliseconds, default 0. A negative <var>duration</var> is considered
-          invalid.
-        </p>
-        <p>
-          <var>startDelay</var> sets the duration of the delay after
-          <code>playEffect()</code> is called until vibration
-          is started, default 0. During the delay interval, the actuator must
-          not vibrate. A negative <var>startDelay</var> is considered invalid.
-        </p>
-        <p>
-          To prevent abuse, the user agent may consider an
-          effect invalid if the total effect duration (the sum of the vibration
-          interval and delay interval) exceeds some maximum duration.
-          A maximum of 5 seconds is recommended.
-        </p>
-        <p>
-          <var>strongMagnitude</var> and <var>weakMagnitude</var> set
-          the vibration intensity levels for the heavier and lighter ERM
-          motors, normalized to the range <code>[0,1]</code>, default 0.
-          Values outside of this range are invalid.
-        </p>
+          <p>
+            A dual-rumble effect is a fixed-length, constant-intensity
+            vibration effect intended for an actuator of type
+            <code>'dual-rumble'</code>. Dual-rumble effects are defined by four
+            parameters.
+          </p>
+          <p>
+            <var>duration</var> sets the duration of the vibration effect in
+            milliseconds, default 0. A negative <var>duration</var> is
+            considered invalid.
+          </p>
+          <p>
+            <var>startDelay</var> sets the duration of the delay after
+            <code>playEffect()</code> is called until vibration
+            is started, default 0. During the delay interval, the actuator must
+            not vibrate. A negative <var>startDelay</var> is considered
+            invalid.
+          </p>
+          <p>
+            To prevent abuse, the user agent may consider an
+            effect invalid if the total effect duration (the sum of the
+            vibration interval and delay interval) exceeds some maximum
+            duration. A maximum of 5 seconds is recommended.
+          </p>
+          <p>
+            <var>strongMagnitude</var> and <var>weakMagnitude</var> set
+            the vibration intensity levels for the heavier and lighter ERM
+            motors, normalized to the range <code>[0,1]</code>, default 0.
+            Values outside of this range are invalid.
+          </p>
         </dd>
       </dl>
     </section>

--- a/extensions.html
+++ b/extensions.html
@@ -46,6 +46,8 @@
               { name: "Brandon Jones", url: "http://tojicode.com/",
                 company: "Google", companyURL: "http://www.google.com/",
                 w3cid: 87824 },
+              { name: "Matt Reynolds", company: "Google",
+                companyURL: "http://www.google.com/"}
           ],
 
           otherLinks: [{
@@ -129,11 +131,11 @@
       and button inputs. It specifically excludes support for more complex
       devices (e.g., those that do motion tracking or haptic feedback).</p>
 
-      <p>However, some uses of gamepads (e.g., those paired with Virtual
-      Reality headsets) rely heavily on those more advanced features. This
-      supplemetary spec describes extensions to the base API to accommodate
-      those use cases. If they prove to be broadly useful, the hope is that
-      they will be eventually merged into the <a href="./">main spec</a>.</p>
+      <p>However, some uses of gamepads rely heavily on those more advanced
+      features. This supplemetary spec describes extensions to the base API to
+      accommodate those use cases. If they prove to be broadly useful, the hope
+      is that they will be eventually merged into the
+      <a href="./">main spec</a>.</p>
 
     </section>
 
@@ -174,30 +176,55 @@
     <section>
       <h2><dfn>GamepadHapticActuator</dfn> Interface</h2>
       <p>
-        Each <code>GamepadHapticActuator</code> corresponds to a motor or other
-        actuator that can apply a force for the purposes of haptic feedback.
+        A <code>GamepadHapticActuator</code> corresponds to a configuration of
+        motors or other actuators that can apply a force for the purposes of
+        haptic feedback.
       </p>
 
       <pre class="idl">
         interface GamepadHapticActuator {
           readonly attribute GamepadHapticActuatorType type;
-          Promise<void> pulse(double value, double duration);
+          Promise<GamepadHapticsResult> playEffect(
+              GamepadHapticEffectType type,
+              GamepadEffectParameters params);
+          Promise<GamepadHapticsResult> reset();
         };
       </pre>
 
       <dl data-dfn-for="GamepadHapticActuator">
-        <dt><dfn data-lt="pulse()">pulse</dfn></dt>
+        <dt><dfn data-lt="playEffect()">playEffect</dfn></dt>
         <dd>
           <p>
-            <code>pulse()</code> applies a value to the actuator for
-            <var>duration</var> milliseconds. The value passed to
-            <code>pulse()</code> is clamped to limits defined by the actuator
-            type. The returned Promise will resolve <code>true</code> once the
-            pulse has completed.
+            <code>playEffect()</code> interprets the effect parameters in
+            <var>params</var> as a haptic effect with the specified
+            <var>type</var> and issues it to the gamepad. It returns a
+            Promise that resolves to <code>'complete'</code> once the effect
+            is complete.
           </p>
           <p>
-            Repeated calls to <code>pulse()</code> override the previous
-            values.
+            If the effect parameters are invalid, <code>playEffect()</code>
+            must return with a Promise resolved to
+            <code>'invalid-parameter'</code>. The validity of the effect
+            parameters is defined by the effect type.
+          </p>
+          <p>
+            If the effect type is not compatible with the actuator,
+            <code>playEffect()</code> must immediately return a Promise resolved
+            to <code>'not-supported'</code>.
+          </p>
+          <p>
+            Repeated calls to <code>playEffect()</code> preempt previous calls.
+            If an effect is preempted, it must resolve its Promise to
+            <code>'preempted'</code> before the new effect is started.
+          </p>
+        </dd>
+
+        <dt><dfn data-lt="reset()">reset</dfn></dt>
+        <dd>
+          <p>
+            <code>reset()</code> stops haptic feedback and preempts any active
+            effects. It returns a Promise that resolves to
+            <code>'complete'</code> once vibration is stopped.
           </p>
         </dd>
       </dl>
@@ -206,26 +233,80 @@
     <section>
       <h2><dfn>GamepadHapticActuatorType</dfn> Enum</h2>
       <p>
-        The actuator type determines the force applied for a given
-        <var>value</var> in <code>GamepadHapticActuator.pulse()</code>.
+        The actuator type describes the capabilities of the gamepad's
+        haptics configuration.
       </p>
 
       <pre class="idl">
         enum GamepadHapticActuatorType {
-          "vibration"
+          "dual-rumble"
         };
       </pre>
 
       <dl data-dfn-for="GamepadHapticActuatorType">
-        <dt><dfn>vibration</dfn></dt>
+        <dt><dfn>dual-rumble</dfn></dt>
         <dd>
-          Vibration is a rumbling effect often implemented as an offset weight
-          driven on a rotational axis. The <code>value</code> of a vibration
-          force determines the frequency of the rumble effect and is
-          normalized between <code>0.0</code> and <code>1.0</code>. The
-          neutral value is <code>0.0</code>.
+          Dual-rumble describes a haptics configuration with an eccentric
+          rotating mass (ERM) vibration motor in each handle of a standard
+          gamepad. In this configuration, either motor is capable of vibrating
+          the whole gamepad. The ERM masses are unequal so that the effects of
+          each can be combined to create more complex haptic effects. A device
+          may expose a vibration actuator with type <code>'dual-rumble'</code>
+          if it has a dual-ERM configuration, or if it has an alternate haptics
+          configuration that is compatible with dual-rumble effects.
         </dd>
       </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadHapticEffectType</dfn> Enum</h2>
+      <p>
+        The effect type defines how the effect parameters are interpreted by
+        the actuator.
+      </p>
+
+      <pre class="idl">
+        enum GamepadHapticEffectType {
+          "dual-rumble"
+        };
+      </pre>
+
+      <dl data-dfn-for="GamepadHapticEffectType">
+        <dt><dfn>dual-rumble</dfn></dt>
+        <dd>
+          A dual-rumble effect is a fixed-length, constant-intensity vibration
+          effect intended for an actuator of type <code>'dual-rumble'</code>.
+          Dual-rumble effects are defined by four parameters.
+          <var>duration</var> sets the duration of the vibration effect in
+          milliseconds, default 0. <var>startDelay</var> sets the duration of
+          the delay after <code>playEffect()</code> is called until vibration
+          is started, default 0. During the delay interval, the actuator must
+          not vibrate. To prevent abuse, the user agent should consider an
+          effect invalid if the total effect duration (the sum of the vibration
+          interval and delay interval) exceeds some reasonable value, say 5
+          seconds. <var>strongMagnitude</var> and <var>weakMagnitude</var> set
+          the vibration intensity levels for the heavier and lighter ERM
+          motors, normalized to the range <code>[0,1]</code>, default 0.
+        </dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2><dfn>GamepadEffectParameters</dfn> Dictionary</h2>
+      <p>
+        A <code>GamepadEffectParameters</code> dictionary contains keys for
+        parameters used by haptic effects. The meaning of each key is defined
+        by the haptic effect, and some keys may be unused.
+      </p>
+
+      <pre class="idl">
+        dictionary GamepadEffectParameters {
+            double duration = 0.0;
+            double startDelay = 0.0;
+            double strongMagnitude = 0.0;
+            double weakMagnitude = 0.0;
+        };
+      </pre>
     </section>
 
     <section>
@@ -341,8 +422,8 @@
       <pre class="idl">
         partial interface Gamepad {
           readonly attribute GamepadHand hand;
-          readonly attribute FrozenArray&lt;GamepadHapticActuator> hapticActuators;
           readonly attribute GamepadPose? pose;
+          readonly attribute GamepadHapticActuator? vibrationActuator;
         };
       </pre>
 
@@ -353,19 +434,20 @@
           held in.
         </dd>
 
-        <dt><dfn>hapticActuators</dfn></dt>
-        <dd>
-          A list of all the haptic actuators in the gamepad. The same object
-          MUST be returned until the user agent needs to return different
-          values (or values in a different order).
-        </dd>
-
         <dt><dfn>pose</dfn></dt>
         <dd>
           The current pose of the gamepad, if supported by the hardware.
           Includes position, orientation, velocity, and acceleration. If the
           hardware cannot supply any pose values, MUST be set to
           <code>null</code>.
+        </dd>
+
+        <dt><dfn>vibrationActuator</dfn></dt>
+        <dd>
+          The haptic configuration used for producing haptic effects that
+          vibrate the whole gamepad. May be null if the gamepad is not capable
+          of haptic vibration effects, or if the device driver does not support
+          haptics.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
Add a single vibrationActuator member to handle haptic effects that affect the whole gamepad.