### PR TITLE
Fix Promise type

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -80,7 +80,7 @@
           wg:           "Web Platform Working Group",
 
           // URI of the public WG page
-          wgURI:        "http://www.w3.org/WebPlatform/WG/",
+          wgURI:        "https://www.w3.org/WebPlatform/WG/",
           license:      "w3c-software-doc",
 
           // name (with the @w3c.org) of the public mailing to which comments are due
@@ -91,7 +91,7 @@
           // This is important for Rec-track documents, do not copy a patent URI from a random
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
-          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/83482/status",
+          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/83482/status",
       };
     </script>
 

--- a/extensions.html
+++ b/extensions.html
@@ -181,7 +181,7 @@
       <pre class="idl">
         interface GamepadHapticActuator {
           readonly attribute GamepadHapticActuatorType type;
-          Promise<void> pulse(double value, double duration);
+          Promise&lt;boolean&gt; pulse(double value, double duration);
         };
       </pre>
 


### PR DESCRIPTION
Also replaced `void` with `boolean` because [the prose says](https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface):

>pulse() applies a value to the actuator for duration milliseconds. The value passed to pulse() is clamped to limits defined by the actuator type. The returned Promise will resolve true once the pulse has completed.