### PR TITLE
fix inline refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
           // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
           // and its maturity status
-          testSuiteURI: "http://w3c-test.org/gamepad/",
+          testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/gamepad",
 
           // if this is a LCWD, uncomment and set the end of its review period
           // lcEnd: "2009-08-05",
@@ -119,9 +119,9 @@
     </section>
 
     <section id='sotd'>
-      If you have comments for this spec, please send them to
+      If you have comments for this spec, please open issues in <a href="https://github.com/w3c/gamepad/">GitHub w3c/gamepad</a>, or send them to
       <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a>
-      with a Subject: prefix of <code>[gamepad]</code>. See
+      with a Subject: prefix of <code>[gamepad]</code>. See <a href="https://github.com/w3c/gamepad/issues/">GitHub w3c/gamepad issues</a> and  
       <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&component=Gamepad&resolution=---">Bugzilla</a>
       for this specification's open bugs.
     </section>
@@ -150,10 +150,10 @@
       specifications:</p>
 
       <ul>
-      <li><code><dfn data-cite="!HTML/multipage/system-state.html#navigator">Navigator</dfn></code> [[!HTML]]</li>
-      <li><a class="externalDFN">DOMHighResTimeStamp</a> [[!HIGHRES-TIME]]</li>
-      <li><a class="externalDFN">WindowAnimationTiming</a> [[!ANIMATION-TIMING]]</li>
-      <li><a class="externalDFN">PerformanceTiming</a> [[!NAVIGATION-TIMING]]</li>
+      <li><code><dfn data-cite="!HTML/system-state.html#navigator">Navigator</dfn></code> [[!HTML]]</li>
+      <li><dfn data-cite="!hr-time-2/#dom-domhighrestimestamp">DOMHighResTimeStamp</dfn></code> [[!HIGHRES-TIME]]</li>
+      <li><dfn data-cite="!HTML/#dom-window-requestanimationframe">requestAnimationFrame</dfn></code> [[!HTML]]</li>
+      <li><dfn data-cite="!navigation-timing/#performancetiming">PerformanceTiming</dfn></code> [[!NAVIGATION-TIMING]]</li>
       </ul>
 
     </section>
@@ -267,7 +267,7 @@
           Timestamp is a monotonically increasing value that allows the author
           to determine if the <code>axes</code> and <code>button</code> data
           have been updated from the hardware. The value must be relative to
-          the <code>navigationStart</code> attribute of the PerformanceTiming
+          the <code>navigationStart</code> attribute of the <a>PerformanceTiming</a>
           interface. Since values are monotonically increasing they can be
           compared to determine the ordering of updates, as newer values will
           always be greater than or equal to older values.
@@ -648,7 +648,7 @@
           <p>
 
             The example below demonstrates typical access to gamepads. Note
-            the relationship with the <a>WindowAnimationTiming</a>
+            the relationship with the <a>requestAnimationFrame</a>
             interface.
           </p>
           <pre class="example">
@@ -673,11 +673,11 @@ window.requestAnimationFrame(runAnimation);
           <div class="practice">
               <p>
               <span id="practice-timing" class="practicelab">Coordination with
-              WindowAnimationTiming</span></p>
+              requestAnimationFrame</span></p>
               <p class="practicedesc">
 
               Interactive applications will typically be using the
-              <a>WindowAnimationTiming</a> interface to drive animation, and
+              <a>requestAnimationFrame</a> interface to drive animation, and
               will want coordinate animation with user gamepad input. As
               such, the gamepad data should be polled as closely as possible
               to immediately before the animation callbacks are executed, and

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
           // only "name" is required
           editors:  [
               { name: "Scott Graham", url: "http://h4ck3r.net/",
-                company: "Google", companyURL: "http://www.google.com/",
+                company: "Google", companyURL: "https://www.google.com/",
                 w3cid: 49028 },
               { name: "Ted Mielczarek", url: "http://ted.mielczarek.org/",
                 company: "Mozilla", companyURL: "http://www.mozilla.org/",
@@ -45,7 +45,7 @@
                 company: "Google", companyURL: "http://www.google.com/",
                 w3cid: 87824 },
               { name: "Steve Agoston",
-                company: "Sony", companyURL: "http://www.sony.com/" },
+                company: "Sony", companyURL: "https://www.sony.com/" },
           ],
 
           github: "https://github.com/w3c/gamepad/",


### PR DESCRIPTION
Update a few inline links.

WebAnimationTiming has been merged to the HTML specs as `requestAnimationFrame` interface.