### PR TITLE
Fix: Standard Gamepad dpad left / right button indices

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,11 +589,11 @@
                 </tr>
                 <tr>
                     <td>buttons[14]</td>
-                    <td>Right button in left cluster</td>
+                    <td>Left button in left cluster</td>
                 </tr>
                 <tr>
                     <td>buttons[15]</td>
-                    <td>Left button in left cluster</td>
+                    <td>Right button in left cluster</td>
                 </tr>
                 <tr>
                     <td>axes[0]</td>


### PR DESCRIPTION
The left and right directional pad buttons were in conflict with the
diagram. Swap them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niedzielski/gamepad/pull/89.html" title="Last updated on Feb 24, 2019, 5:04 AM UTC (7b1dc1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/89/0dff67d...niedzielski:7b1dc1e.html" title="Last updated on Feb 24, 2019, 5:04 AM UTC (7b1dc1e)">Diff</a>