### PR TITLE
Editorial: reduce dependencies using newer syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,20 +163,6 @@
       </p>
       <ul>
         <li>
-          <code><dfn data-cite=
-          "HTML/system-state.html#navigator">Navigator</dfn></code> [[HTML]].
-        </li>
-        <li>
-          <dfn data-cite=
-          "hr-time-2#dom-domhighrestimestamp">DOMHighResTimeStamp</dfn>
-          [[HIGHRES-TIME]].
-        </li>
-        <li>
-          <dfn data-cite=
-          "HTML/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">
-          requestAnimationFrame()</dfn> method [[HTML]].
-        </li>
-        <li>
           <dfn data-cite=
           "navigation-timing#performancetiming">PerformanceTiming</dfn>
           [[NAVIGATION-TIMING]].
@@ -221,7 +207,7 @@
       <p>
         This interface defines an individual gamepad device.
       </p>
-      <pre class="idl">
+      <pre class="idl" data-cite="HR-TIME">
         [Exposed=Window]
         interface Gamepad {
           readonly attribute DOMString id;
@@ -713,7 +699,7 @@
       </h2>
       <p>
         The example below demonstrates typical access to gamepads. Note the
-        relationship with the <a>requestAnimationFrame()</a> method.
+        relationship with the {{AnimationFrameProvider/requestAnimationFrame()}} method.
       </p>
       <pre class="example js">
         function runAnimation() {
@@ -731,7 +717,7 @@
         <code>requestAnimationFrame()</code></span>
         <p class="practicedesc">
           Interactive applications will typically be using the
-          <a>requestAnimationFrame()</a> method to drive animation, and will
+          {{AnimationFrameProvider/requestAnimationFrame()}} method to drive animation, and will
           want coordinate animation with user gamepad input. As such, the
           gamepad data should be polled as closely as possible to immediately
           before the animation callbacks are executed, and with frequency


### PR DESCRIPTION
Could not remove `PerformanceTiming` from dependencies as it's not available in ReSpec's xref database.

---

Closes #???

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/gamepad/pull/108.html" title="Last updated on Sep 22, 2019, 12:59 PM UTC (30e8b69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/108/f01996b...sidvishnoi:30e8b69.html" title="Last updated on Sep 22, 2019, 12:59 PM UTC (30e8b69)">Diff</a>