### PR TITLE
chore(ci): use ReSpec auto-publish action

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
       - uses: sidvishnoi/respec-w3c-auto-publish@master
         with:
           ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -13,22 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+      - uses: sidvishnoi/respec-w3c-auto-publish@master
         with:
-          node-version: 12
-      - name: Do spec validation
-        env:
+          ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           GH_USER: ${{ secrets.GH_USER }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          npm i respec respec-validator
-          $(npm bin)/respec-validator --gh-user=$GH_USER --gh-token=$GH_TOKEN index.html
-      - name: Publish to /TR/
-        if: github.event_name != 'pull_request'
-        env:
-          TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          URL: "https://w3c.github.io/gamepad/W3CTRMANIFEST"
-          DECISION: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
+          ECHIDNA_MANIFEST_URL: "https://w3c.github.io/gamepad/W3CTRMANIFEST"
+          WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
           CC: "mcaceres@mozilla.com"
-        run: |
-          echo "If it fails, check https://lists.w3.org/Archives/Public/public-tr-notifications/"
-          curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN" --data "cc=$CC"


### PR DESCRIPTION
Simplifies validation and publishing using a new GitHub action.
Publish is done only on merge. Validation is done on PR as well as merge.