### PR TITLE
Require secure context for gamepad state and events

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
       }
     </style>
   </head>
-  <body>
+  <body data-cite="secure-contexts">
     <section id='abstract'>
       <p>
         The Gamepad specification defines a low-level interface that represents
@@ -212,7 +212,7 @@
         This interface defines an individual gamepad device.
       </p>
       <pre class="idl" data-cite="HR-TIME">
-        [Exposed=Window]
+        [Exposed=Window, SecureContext]
         interface Gamepad {
           readonly attribute DOMString id;
           readonly attribute long index;
@@ -321,7 +321,7 @@
         device.
       </p>
       <pre class="idl">
-        [Exposed=Window]
+        [Exposed=Window, SecureContext]
         interface GamepadButton {
           readonly attribute boolean pressed;
           readonly attribute boolean touched;
@@ -428,6 +428,12 @@
           each Gamepad present at the index in the array specified by its
           {{Gamepad/index}} attribute. Array indices for which there is no
           connected Gamepad with the corresponding index should return null.
+
+          <p>
+          If the <a>environment settings object</a> is a <a>non-secure
+          context</a> return an empty array. Optionally, inform the developer
+          that the API can only be used from <a>secure contexts</a>.
+          </p>
           
           <p>
           The gamepad state returned from getGamepads() does not reflect
@@ -455,7 +461,7 @@
         <dfn>GamepadEvent</dfn> Interface
       </h2>
       <pre class="idl" data-cite="DOM">
-        [Exposed=Window]
+        [Exposed=Window, SecureContext]
 
         interface GamepadEvent: Event {
           constructor(DOMString type, GamepadEventInit eventInitDict);
@@ -757,6 +763,10 @@
         page was loaded, the <a>gamepadconnected</a> event SHOULD be dispatched
         when the user presses a button or moves an axis.
       </p>
+      <p>
+        A <a>user agent</a> MUST NOT dispatch this event type if the
+        <a>environment settings object</a> is a <a>non-secure context</a>.
+      </p>
     </section>
     <section>
       <h3 id="event-gamepaddisconnected">
@@ -775,6 +785,10 @@
         <a>user agent</a> has previously dispatched a <a>gamepadconnected</a>
         event for that gamepad to a window, a <a>gamepaddisconnected</a> event
         MUST be dispatched to that same window.
+      </p>
+      <p>
+        A <a>user agent</a> MUST NOT dispatch this event type if the
+        <a>environment settings object</a> is a <a>non-secure context</a>.
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -413,34 +413,35 @@
       </pre>
       <dl>
         <dt>
-          <dfn>getGamepads</dfn>
+          <dfn>getGamepads()</dfn>
         </dt>
         <dd>
-          Retrieve a snapshot of the data for the the currently connected and
-          interacted-with gamepads. Gamepads MUST only appear in the list if
-          they are currently connected to the <a>user agent</a>, and at least
-          one device has been interacted with by the user. If no devices have
-          been interacted with, devices MUST NOT appear in the list to avoid a
-          malicious page from fingerprinting the user. The length of the array
-          returned MUST be one more than the maximum index value of the Gamepad
-          objects returned in the array. The entries in the array MUST be the
-          set of Gamepad objects that are visible to the current page, with
-          each Gamepad present at the index in the array specified by its
-          {{Gamepad/index}} attribute. Array indices for which there is no
-          connected Gamepad with the corresponding index should return null.
-
-          <p>
-          If the <a>environment settings object</a> is a <a>non-secure
-          context</a> return an empty array. Optionally, inform the developer
-          that the API can only be used from <a>secure contexts</a>.
+          <p class="note">
+            The gamepad state returned from {{Navigator/getGamepads()}} does
+            not reflect disconnection or connection until after the
+            <a>gamepaddisconnected</a> or <a>gamepadconnected</a> events have
+            fired.
           </p>
-          
           <p>
-          The gamepad state returned from getGamepads() does not reflect
-          disconnection or connection until after the <a>gamepaddisconnected</a>
-          or <a>gamepadconnected</a> events have fired.
+            If the <a>environment settings object</a> is a <a>non-secure
+            context</a> return an empty array. Optionally, inform the developer
+            that the API can only be used from <a>secure contexts</a>.
           </p>
-
+          <p>
+            Otherwise, retrieve a snapshot of the data for the the currently
+            connected and interacted-with gamepads. Gamepads MUST only appear
+            in the list if they are currently connected to the <a>user
+            agent</a>, and at least one device has been interacted with by the
+            user. If no devices have been interacted with, devices MUST NOT
+            appear in the list to avoid a malicious page from fingerprinting
+            the user. The length of the array returned MUST be one more than
+            the maximum index value of the Gamepad objects returned in the
+            array. The entries in the array MUST be the set of Gamepad objects
+            that are visible to the current page, with each Gamepad present at
+            the index in the array specified by its {{Gamepad/index}}
+            attribute. Array indices for which there is no connected Gamepad
+            with the corresponding index should return null.
+          </p>
           <p>
             As an example, if there is one connected gamepad with an index of
             1, then the following code snippet describes the expected behavior:


### PR DESCRIPTION
Closes #113

The following tasks have been completed:

 * [x] Modified Web platform tests - will be updated automatically after merge. 

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=215020)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1591329)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nondebug/gamepad/pull/120.html" title="Last updated on Oct 29, 2020, 10:59 PM UTC (a67076f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/120/792597d...nondebug:a67076f.html" title="Last updated on Oct 29, 2020, 10:59 PM UTC (a67076f)">Diff</a>