### PR TITLE
Editorial: Fix a few inconsistencies in "GamepadButton Interface"

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,24 +336,24 @@
           The pressed state of the button. This property MUST be true if the
           button is currently pressed, and false if it is not pressed. For
           buttons which do not have a digital switch to indicate a pure pressed
-          or released state, the user agent MUST choose a threshold value to
-          indicate the button as pressed when its value is above a certain
-          amount. If the platform API gives a recommended value, the user agent
-          SHOULD use that. In other cases, the user agent SHOULD choose some
-          other reasonable value.
+          or released state, the <a>user agent</a> MUST choose a threshold
+          value to indicate the button as pressed when its value is above a
+          certain amount. If the platform API gives a recommended value, the
+          user agent SHOULD use that. In other cases, the user agent SHOULD
+          choose some other reasonable value.
         </dd>
         <dt>
           <dfn>touched</dfn> attribute
         </dt>
         <dd>
           The touched state of the button. If the button is capable of
-          detecting touch this property MUST be true if the button is currently
-          being touched and false otherwise. If the button is not capable of
-          detecting touch and is capable of reporting an analog value this
-          property MUST be true if the value property is greater than zero and
-          false if the value is 0. If the button is not capable of detecting
-          touch and can only report a digital value this property MUST mirror
-          the pressed value.
+          detecting touch, this property MUST be true if the button is
+          currently being touched, and false otherwise. If the button is not
+          capable of detecting touch and is capable of reporting an analog
+          value, this property MUST be true if the value property is greater
+          than 0, and false if the value is 0. If the button is not capable of
+          detecting touch and can only report a digital value, this property
+          MUST mirror the <a>pressed</a> attribute.
         </dd>
         <dt>
           <dfn>value</dfn> attribute
@@ -364,7 +364,7 @@
           be linearly normalized to the range [0.0 .. 1.0]. 0.0 MUST mean fully
           unpressed, and 1.0 MUST mean fully pressed. For buttons without an
           analog sensor, only the values 0.0 and 1.0 for fully unpressed and
-          fully pressed MUST be provided.
+          fully pressed respectively, MUST be provided.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
This PR is relatively straightforward. All in all, there were only a couple of editorial changes, all of which in the [*GamepadButton* Interface](https://w3c.github.io/gamepad/#gamepadbutton-interface) section:

- A few missing commas have been added.
- An instance of "value" has been changed to "attribute", because the "`pressed` attribute" had been specified under that nomenclature, and a property shouldn't be able to mirror a value, but rather mirror another property.
- `<a>` has been used to reference the definition of `pressed`.
- There used to be an instance where both "0" and "zero" would be used in the same sentence. Since both referenced the same value, I've replaced "0" with "zero".
- The term "respectively" has been added in a phrase where two numeric values were assigned to two button states in order to avoid confusion.

-----

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kri/gamepad/pull/122.html" title="Last updated on Nov 13, 2019, 11:12 AM UTC (d5155a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/122/eb3e7ad...kri:d5155a7.html" title="Last updated on Nov 13, 2019, 11:12 AM UTC (d5155a7)">Diff</a>