### PR TITLE
chore(ci): use the spec-prod GitHub action

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -15,6 +15,5 @@ jobs:
       - uses: sidvishnoi/spec-prod@v1
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_MANIFEST_URL: "https://w3c.github.io/gamepad/W3CTRMANIFEST"
           W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
           W3C_NOTIFICATIONS_CC: "mcaceres@mozilla.com"

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -11,7 +11,7 @@ jobs:
     name: Validate and Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: sidvishnoi/spec-prod@v1
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: sidvishnoi/respec-w3c-auto-publish@master
+      - uses: sidvishnoi/spec-prod@v1
         with:
-          ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          GH_USER: ${{ secrets.GH_USER }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          ECHIDNA_MANIFEST_URL: "https://w3c.github.io/gamepad/W3CTRMANIFEST"
-          WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
-          CC: "mcaceres@mozilla.com"
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_MANIFEST_URL: "https://w3c.github.io/gamepad/W3CTRMANIFEST"
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
+          W3C_NOTIFICATIONS_CC: "mcaceres@mozilla.com"

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,2 +1,0 @@
-index.html?specStatus=WD&shortName=gamepad respec
-standard_gamepad.svg


### PR DESCRIPTION
We plan to deprecate [respec-w3c-auto-publish](https://github.com/w3c/respec-w3c-auto-publish) action in favor of a more generic [`spec-prod`](https://github.com/sidvishnoi/spec-prod/) action. The newer action is more consistent and requires fewer inputs.

It also supports deploying generated static ReSpec document to GitHub pages, but we probably don't want to switch to that here yet, as ReSpec runtime has some nice features.