### PR TITLE
Add gamepad light indicator extension

### DIFF
--- a/extensions.html
+++ b/extensions.html
@@ -377,7 +377,7 @@
       </pre>
       
       <dl data-dfn-for="GamepadLightColor">
-        <dt><dfn>red</dt></dfn>
+        <dt><dfn>red</dt> member</dfn>
         <dd>
           Red component of the light color, or non-zero value for an
           <code>on-off</code> light indicator that indicates ON.

--- a/extensions.html
+++ b/extensions.html
@@ -450,8 +450,7 @@
           readonly attribute GamepadHand hand;
           readonly attribute FrozenArray&lt;GamepadHapticActuator> hapticActuators;
           readonly attribute GamepadPose? pose;
-          readonly attribute FrozenArray&lt;GamepadLightIndicator>?
-          lightIndicators;
+          readonly attribute FrozenArray&lt;GamepadLightIndicator>? lightIndicators;
         };
       </pre>
 

--- a/extensions.html
+++ b/extensions.html
@@ -383,7 +383,7 @@
           <code>on-off</code> light indicator that indicates ON.
         </dd>
         
-        <dt><dfn>green</dt></dfn>
+        <dt><dfn>green</dt> member</dfn>
         <dd>
           Blue component of the light color, or non-zero value for an
           <code>on-off</code> light indicator that indicates ON.

--- a/extensions.html
+++ b/extensions.html
@@ -370,9 +370,9 @@
     
       <pre class="idl">
         dictionary GamepadLightColor {
-          required octet red;
-          required octet green;
-          required octet blue;
+          octet red = 0;
+          octet green = 0;
+          octet blue = 0;
        };
       </pre>
       

--- a/extensions.html
+++ b/extensions.html
@@ -334,6 +334,109 @@
         </dd>
       </dl>
     </section>
+    
+    <section>
+      <h2><dfn>GamepadLightIndicatorType</dfn> Enum</h2>
+      <p>
+        This enum defines the type of light indicators supported by gamepads.
+      </p>
+      
+      <pre class="idl">
+        enum GamepadLightIndicatorType {
+          "on-off",
+          "rgb"
+        };
+      </pre>
+      
+      <dl data-dfn-for="GamepadLightIndicatorType">
+        <dt>"<dfn>on-off</dfn>"</dt>
+        <dd>
+          Light indicator that supports a single color.
+        </dd>
+        
+        <dt>"<dfn>rgb</dfn>"</dt>
+        <dd>
+          Light indicator that supports multiple colors.
+        </dd>
+      </dl>
+    </section>
+    
+    <section>
+      <h2><dfn>GamepadLightColor</dfn></h2>
+      <p>
+        This represents the color of a light indicator. The default value should
+        be set to 0 for red, green, and blue.
+      </p>
+    
+      <pre class="idl">
+        dictionary GamepadLightColor {
+          required octet red;
+          required octet green;
+          required octet blue;
+       };
+      </pre>
+      
+      <dl data-dfn-for="GamepadLightColor">
+        <dt><dfn>red</dt></dfn>
+        <dd>
+          Red component of the light color, or non-zero value for an
+          <code>on-off</code> light indicator that indicates ON.
+        </dd>
+        
+        <dt><dfn>green</dt></dfn>
+        <dd>
+          Blue component of the light color, or non-zero value for an
+          <code>on-off</code> light indicator that indicates ON.
+        </dd>
+        
+        <dt><dfn>blue</dt></dfn>
+        <dd>
+          Green component of the light color, or non-zero value for an
+          <code>on-off</code> light indicator that indicates ON.
+        </dd>
+      </dl>
+    </section>
+    
+    <section>
+      <h2><dfn>GamepadLightIndicator</dfn></h2>
+      <p>
+        This interface defines a light indicator.
+      </p>
+      
+      <pre class="idl">
+        [Exposed=Window, SecureContext]
+        interface GamepadLightIndicator {
+          readonly attribute GamepadLightIndicatorType type;
+        
+          Promise&lt;long&gt; setColor(GamepadLightColor color);
+      };
+      </pre>
+      
+      <dl data-dfn-for="GamepadLightIndicator">
+        <dt><dfn>type</dt></dfn>
+        <dd>
+          Type of light indicator supported by the gamepad.
+        </dd>
+        
+        <dt><dfn>setColor</dt></dfn>
+        <dd>
+          Sets the color of a light indicator, or sets the light indicator to ON
+          or OFF.
+          
+          For <code>on-off</code> light indicators, one or more non zero values
+          denotes the light indicator is ON, whereas a zero value for all
+          components indicates the light indicator is OFF.
+          
+          For RGB light indicators, one or more non zero values specify the
+          color of the light indicator, whereas all zero values indicate the
+          light indicator is OFF.
+          
+          The returned Promise will resolve <code>true</code> when setting the
+          color has succeeded, and will reject the device API error code on
+          failure.
+        </dd>
+      </dl>
+    </section>
 
     <section>
       <h2>Partial <dfn>Gamepad</dfn> Interface</h2>
@@ -347,6 +450,8 @@
           readonly attribute GamepadHand hand;
           readonly attribute FrozenArray&lt;GamepadHapticActuator> hapticActuators;
           readonly attribute GamepadPose? pose;
+          readonly attribute FrozenArray&lt;GamepadLightIndicator>?
+          lightIndicators;
         };
       </pre>
 
@@ -370,6 +475,12 @@
           Includes position, orientation, velocity, and acceleration. If the
           hardware cannot supply any pose values, MUST be set to
           <code>null</code>.
+        </dd>
+        
+        <dt><dfn>lightIndicators</dfn></dt>
+        <dd>
+          A list of all light indicators in the gamepad. <code>null</code> if
+          the gamepad does not have or does not support a light indicator.
         </dd>
       </dl>
     </section>

--- a/extensions.html
+++ b/extensions.html
@@ -508,7 +508,7 @@
           readonly attribute GamepadHand hand;
           readonly attribute FrozenArray&lt;GamepadHapticActuator> hapticActuators;
           readonly attribute GamepadPose? pose;
-          readonly attribute FrozenArray&lt;GamepadLightIndicator>? lightIndicators;
+          readonly attribute FrozenArray&lt;GamepadLightIndicator> lightIndicators;
           readonly attribute FrozenArray&lt;GamepadTouch>? touchEvents;
         };
       </pre>

--- a/extensions.html
+++ b/extensions.html
@@ -427,8 +427,8 @@
           
           <p>
           For <code>on-off</code> light indicators, one or more non zero values
-          denotes the light indicator is ON, whereas a zero value for all
-          components indicates the light indicator is OFF.
+          denotes the light indicator is on, whereas a zero value for all
+          components indicates the light indicator is off.
           </p>
           
           <p>

--- a/extensions.html
+++ b/extensions.html
@@ -362,10 +362,9 @@
     </section>
     
     <section>
-      <h2><dfn>GamepadLightColor</dfn></h2>
+      <h2><dfn>GamepadLightColor</dfn> dictionary</h2>
       <p>
-        This represents the color of a light indicator. The default value should
-        be set to 0 for red, green, and blue.
+        This represents the color of a light indicator.
       </p>
     
       <pre class="idl">
@@ -408,7 +407,7 @@
         interface GamepadLightIndicator {
           readonly attribute GamepadLightIndicatorType type;
         
-          Promise&lt;long&gt; setColor(GamepadLightColor color);
+          Promise&lt;undefined&gt; setColor(GamepadLightColor color);
       };
       </pre>
       
@@ -539,7 +538,7 @@
         <dd>
           A list of all light indicators in the gamepad. The array is empty if
           the gamepad does not have, or does not support, a light indicator.
-
+       </dd>
         <dt><dfn>touchEvents</dfn></dt>
         <dd>
           A list of touch events generated from all touch surfaces. <code>null</code>

--- a/extensions.html
+++ b/extensions.html
@@ -420,20 +420,28 @@
         
         <dt><dfn>setColor</dt></dfn>
         <dd>
+          <p>
           Sets the color of a light indicator, or sets the light indicator to ON
           or OFF.
+          </p>
           
+          <p>
           For <code>on-off</code> light indicators, one or more non zero values
           denotes the light indicator is ON, whereas a zero value for all
           components indicates the light indicator is OFF.
+          </p>
           
+          <p>
           For RGB light indicators, one or more non zero values specify the
           color of the light indicator, whereas all zero values indicate the
           light indicator is OFF.
+          </p>
           
+          <p>
           The returned Promise will resolve <code>true</code> when setting the
           color has succeeded, and will reject the device API error code on
           failure.
+          </p>
         </dd>
       </dl>
     </section>

--- a/extensions.html
+++ b/extensions.html
@@ -537,8 +537,8 @@
         
         <dt><dfn>lightIndicators</dfn></dt>
         <dd>
-          A list of all light indicators in the gamepad. <code>null</code> if
-          the gamepad does not have or does not support a light indicator.
+          A list of all light indicators in the gamepad. The array is empty if
+          the gamepad does not have, or does not support, a light indicator.
 
         <dt><dfn>touchEvents</dfn></dt>
         <dd>

--- a/extensions.html
+++ b/extensions.html
@@ -418,7 +418,7 @@
           Type of light indicator supported by the gamepad.
         </dd>
         
-        <dt><dfn>setColor</dt></dfn>
+        <dt><dfn>setColor()</dt> method</dfn>
         <dd>
           <p>
           Sets the color of a light indicator, or sets the light indicator to ON

--- a/extensions.html
+++ b/extensions.html
@@ -389,7 +389,7 @@
           <code>on-off</code> light indicator that indicates ON.
         </dd>
         
-        <dt><dfn>blue</dt></dfn>
+        <dt><dfn>blue</dt> member</dfn>
         <dd>
           Green component of the light color, or non-zero value for an
           <code>on-off</code> light indicator that indicates ON.


### PR DESCRIPTION
Closes #67

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1523351)
