### PR TITLE
Add the xr-standard mapping type

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
         enum GamepadMappingType {
           "",
           "standard",
+          "xr-standard",
         };
       </pre>
       <dl>
@@ -375,6 +376,18 @@
         <dd>
           The Gamepad's controls have been mapped to the <a href=
           "#remapping">Standard Gamepad layout</a>.
+        </dd>
+        <dt>
+          <dfn>xr-standard</dfn>
+        </dt>
+        <dd>
+          The Gamepad's controls have been mapped to the <a href=
+          "https://immersive-web.github.io/webxr-gamepads-module/#xr-standard-gamepad-mapping">
+          XR Standard Gamepad Layout</a>. This mapping is reserved for use by
+          the <a href="https://immersive-web.github.io/webxr-gamepads-module">
+          WebXR Gamepad Module</a>. Gamepads returned by
+          {{Navigator/getGamepads()}} MUST NOT report a <a>mapping</a> of
+          {{GamepadMappingType["xr-standard"]}}.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
This was reported in https://github.com/immersive-web/webxr-gamepads-module/issues/35

This property was already defined in the [WebXR Gamepad Module](https://immersive-web.github.io/webxr-gamepads-module/#xr-standard-gamepad-mapping), but since WebIDL does not allow for partial enums we ended up repeating the enum with the new value in that spec. This has apparently caused some tooling issues as there are now two conflicting copies of the same enum within the W3C spec library.

I would love it if there was a way to keep this value better scoped to the relevant spec, but lacking that it seems best to lift this up into the main gamepad spec with links off to the definition of the mapping in the WebXR spec and a note that it is reserved for use by that spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/146.html" title="Last updated on Mar 17, 2021, 1:33 AM UTC (8bd4404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/146/e84cb46...8bd4404.html" title="Last updated on Mar 17, 2021, 1:33 AM UTC (8bd4404)">Diff</a>