### PR TITLE
getGamepad() check if doc is fully active

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,10 +1112,15 @@
           The {{Navigator/getGamepads()}} method steps are:
         </p>
         <ol>
-          <li>If the [=current settings object=]'s [=environment settings
-          object / responsible document=] is not [=allowed to use=] the
-          `"gamepad"` permission, then [=exception/throw=] a
-          {{"SecurityError"}} {{DOMException}} and abort these steps.
+          <li>Let |doc| be the [=current settings object=]'s [=environment
+          settings object / responsible document=].
+          </li>
+          <li>If |doc| is `null` or |doc| is not [=Document/fully active=],
+          then return an empty [=list=].
+          </li>
+          <li>If |doc| is not [=allowed to use=] the `"gamepad"` permission,
+          then [=exception/throw=] a {{"SecurityError"}} {{DOMException}} and
+          abort these steps.
           </li>
           <li>If [=this=].{{Navigator/[[hasGamepadGesture]]}} is `false`, then
           return an empty [=list=].


### PR DESCRIPTION
I think we are missing this check here... in theory, you could pull gamepads() from a non-fully active document by holding a reference to `navigator` after physical gamepad activation. We currently prevent events firing if not fully active, but we might as well also return an empty array in this check too. 

The following tasks have been completed:

 * [X] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/31640)

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=230136)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1741343)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/157.html" title="Last updated on Nov 17, 2021, 11:56 AM UTC (1c67615)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/157/da113e6...1c67615.html" title="Last updated on Nov 17, 2021, 11:56 AM UTC (1c67615)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/157.html" title="Last updated on Feb 11, 2022, 12:41 AM UTC (1c67615)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/157/da113e6...1c67615.html" title="Last updated on Feb 11, 2022, 12:41 AM UTC (1c67615)">Diff</a>