### PR TITLE
Add -1 to the set of allowed indices

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,15 +325,10 @@
           <dfn>index</dfn> attribute
         </dt>
         <dd>
-          The index of the gamepad in the {{Navigator}}, if it is exposed via
-          {{Navigator/getGamepads()}}. When multiple gamepads are connected to
+          The index of the gamepad in the {{Navigator}}. When multiple gamepads are connected to
           a [=user agent=], indices MUST be assigned on a first-come,
-          first-serve basis, starting at zero. If a gamepad is
-          disconnected, previously assigned indices MUST NOT be reassigned to
-          gamepads that continue to be connected. However, if a gamepad is
-          disconnected, and subsequently the same or a different gamepad is
-          then connected, the lowest previously used index MUST be reused.
-          Gamepad objects not exposed via {{Navigator/getGamepads()}}
+          first-serve basis, starting at zero according to the steps in [=select a gamepad index=].
+          Gamepad objects not intended to be exposed via {{Navigator/getGamepads()}}
           MUST have an {{Gamepad/index}} of <code>-1</code>.
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -328,8 +328,8 @@
           The index of the gamepad in the {{Navigator}}. When multiple gamepads are connected to
           a [=user agent=], indices MUST be assigned on a first-come,
           first-serve basis, starting at zero according to the steps in [=select a gamepad index=].
-          Gamepad objects not intended to be exposed via {{Navigator/getGamepads()}}
-          MUST have an {{Gamepad/index}} of <code>-1</code>.
+          <span class="note"> Gamepad objects not intended to be exposed via {{Navigator/getGamepads()}}
+          may have an {{Gamepad/index}} of <code>-1</code></span>.
         </dd>
         <dt>
           <dfn>connected</dfn> attribute

--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
         <dd>
           The index of the gamepad in the {{Navigator}}. When multiple gamepads are connected to
           a [=user agent=], indices MUST be assigned on a first-come,
-          first-serve basis, starting at zero according to the steps in [=select a gamepad index=].
+          first-serve basis, starting at zero according to the steps in [=selecting an unused gamepad index=].
           <span class="note"> Gamepad objects not intended to be exposed via {{Navigator/getGamepads()}}
           may have an {{Gamepad/index}} of <code>-1</code></span>.
         </dd>

--- a/index.html
+++ b/index.html
@@ -325,13 +325,16 @@
           <dfn>index</dfn> attribute
         </dt>
         <dd>
-          The index of the gamepad in the {{Navigator}}. When multiple gamepads
-          are connected to a [=user agent=], indices MUST be assigned on a
-          first-come, first-serve basis, starting at zero. If a gamepad is
+          The index of the gamepad in the {{Navigator}}, if it is exposed via
+          {{Navigator/getGamepads()}}. When multiple gamepads are connected to
+          a [=user agent=], indices MUST be assigned on a first-come,
+          first-serve basis, starting at zero. If a gamepad is
           disconnected, previously assigned indices MUST NOT be reassigned to
           gamepads that continue to be connected. However, if a gamepad is
           disconnected, and subsequently the same or a different gamepad is
           then connected, the lowest previously used index MUST be reused.
+          Gamepad objects not exposed via {{Navigator/getGamepads()}}
+          MUST have an {{Gamepad/index}} of <code>-1</code>.
         </dd>
         <dt>
           <dfn>connected</dfn> attribute


### PR DESCRIPTION
Closes https://github.com/immersive-web/webxr-gamepads-module/issues/27


The WebXR module constructs Gamepads that are not exposed via `navigator.getGamepads()`, this adds a `-1` value for `index` that can accomodate them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/gamepad/pull/158.html" title="Last updated on Oct 5, 2022, 5:25 PM UTC (535d486)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/158/27e39c2...Manishearth:535d486.html" title="Last updated on Oct 5, 2022, 5:25 PM UTC (535d486)">Diff</a>