### PR TITLE
Replace "current settings object's relevant global object"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,8 +1112,8 @@
           The {{Navigator/getGamepads()}} method steps are:
         </p>
         <ol>
-          <li>Let |doc| be the [=current settings object=]'s [=relevant global
-          object=]'s [=associated `Document`=].
+          <li>Let |doc| be the [=current global object=]'s [=associated
+          `Document`=].
           </li>
           <li>If |doc| is `null` or |doc| is not [=Document/fully active=],
           then return an empty [=list=].
@@ -1513,9 +1513,8 @@
         steps:
       </p>
       <ol>
-        <li>Let |document:Document?| be the [=current settings object=]'s
-        [=relevant global object=]'s [=associated `Document`=]; otherwise
-        `null`.
+        <li>Let |document:Document?| be the [=current global object=]'s
+        [=associated `Document`=]; otherwise `null`.
         </li>
         <li>If |document| is not `null` and is not [=allowed to use=] the
         `"gamepad"` permission, then abort these steps.


### PR DESCRIPTION
Use "current global object" instead.

Closes #170

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/171.html" title="Last updated on Sep 14, 2022, 8:47 PM UTC (d895604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/171/fea8ad7...d895604.html" title="Last updated on Sep 14, 2022, 8:47 PM UTC (d895604)">Diff</a>