### PR TITLE
Editorial: fix broken xref

### DIFF
--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,7 @@
       </h2>
       <p>
         This specification defines a policy-controlled feature identified by
-        the string <dfn class="permission">"gamepad"</dfn>. Its [=policy-controlled feature/default allowlist=] is `'self'`.
+        the string <dfn class="permission">"gamepad"</dfn>. Its [=policy-controlled feature/default allowlist=] is [=default allowlist/'self'=].
       </p>
       <div class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,9 @@
       </h2>
       <p>
         This specification defines a policy-controlled feature identified by
-        the string <dfn class="permission">"gamepad"</dfn>. Its [=policy-controlled feature/default allowlist=] is [=default allowlist/'self'=].
+        the string <dfn class="permission">"gamepad"</dfn>. Its
+        [=policy-controlled feature/default allowlist=] is [=default
+        allowlist/'self'=].
       </p>
       <div class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -1645,8 +1645,7 @@
       </h2>
       <p>
         This specification defines a policy-controlled feature identified by
-        the string <dfn class="permission">"gamepad"</dfn>. Its [=default
-        allowlist=] is `'self'`.
+        the string <dfn class="permission">"gamepad"</dfn>. Its [=policy-controlled feature/default allowlist=] is `'self'`.
       </p>
       <div class="note">
         <p>


### PR DESCRIPTION
Fixes the error being shown by CI.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/184.html" title="Last updated on Feb 10, 2023, 4:30 AM UTC (20f639b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/184/c006cb6...20f639b.html" title="Last updated on Feb 10, 2023, 4:30 AM UTC (20f639b)">Diff</a>