### PR TITLE
Allow initializing the gamepad index to a specific value

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,8 +650,9 @@
           Constructing a `Gamepad`
         </h3>
         <p>
-          <dfn>A new `Gamepad`</dfn> representing a connected gamepad device is
-          constructed by performing the following steps:
+          <dfn>A new `Gamepad`</dfn> with optional |index:long| representing a
+          connected gamepad device is constructed by performing the following
+          steps:
         </p>
         <ol>
           <li>Let |gamepad:Gamepad| be a newly created {{Gamepad}} instance:
@@ -659,8 +660,14 @@
               <li>Initialize |gamepad|'s {{Gamepad/id}} attribute to an
               identification string for the gamepad.
               </li>
-              <li>Initialize |gamepad|'s {{Gamepad/index}} attribute to the
-              result of [=selecting an unused gamepad index=] for |gamepad|.
+              <li>Initialize |gamepad|'s {{Gamepad/index}} attribute to:
+                <ul>
+                  <li>|index|, if |index| is provided, or
+                  </li>
+                  <li>The result of [=selecting an unused gamepad index=] for
+                  |gamepad|.
+                  </li>
+                </ul>
               </li>
               <li>Initialize |gamepad|'s {{Gamepad/mapping}} attribute to the
               result of [=selecting a mapping=] for the gamepad device.


### PR DESCRIPTION
Closes #???

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/193.html" title="Last updated on Feb 9, 2024, 7:09 PM UTC (be68590)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/193/4b33578...be68590.html" title="Last updated on Feb 9, 2024, 7:09 PM UTC (be68590)">Diff</a>