### PR TITLE
Make eventInitDict param optional in GamepadEvent constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1771,7 +1771,7 @@
         </h3>
         <pre class="idl" data-cite="DOM">
         dictionary GamepadEventInit : EventInit {
-          required Gamepad gamepad;
+          Gamepad? gamepad = null;
         };
       </pre>
         <dl data-dfn-for="GamepadEventInit">

--- a/index.html
+++ b/index.html
@@ -1752,7 +1752,7 @@
         [Exposed=Window]
 
         interface GamepadEvent: Event {
-          constructor(DOMString type, GamepadEventInit eventInitDict);
+          constructor(DOMString type, optional GamepadEventInit eventInitDict);
           [SameObject] readonly attribute Gamepad gamepad;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -1752,7 +1752,7 @@
         [Exposed=Window]
 
         interface GamepadEvent: Event {
-          constructor(DOMString type, optional GamepadEventInit eventInitDict);
+          constructor(DOMString type, optional GamepadEventInit eventInitDict = {});
           [SameObject] readonly attribute Gamepad gamepad;
         };
       </pre>


### PR DESCRIPTION
Closes #216

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [X] WebKit
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/pull/217.html" title="Last updated on Feb 13, 2026, 12:49 AM UTC (ffd83a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/217/0186e68...ffd83a2.html" title="Last updated on Feb 13, 2026, 12:49 AM UTC (ffd83a2)">Diff</a>