### PR TITLE
ci: pin spec-prod to v2.12.5

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: w3c/spec-prod@v2
+      - uses: w3c/spec-prod@v2.12.5
         with:
           VALIDATE_INPUT_MARKUP: true
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}


### PR DESCRIPTION
The `w3c/spec-prod@v2` floating tag (currently v2.13.0, released 2026-03-04) fails on every PR and on `gh-pages` push runs with:

```
Command `respec -s "..." -o "index.html.built.html" --verbose -t 20 -e` failed with exit code: 127.
```

Exit 127 = `respec` not found on PATH. Reproduced on:

- This repo's recent `gh-pages` push run (21970293086, 2026-02-13)
- Two unrelated PR runs (21970234675, 24270554650)
- A fresh re-run today (25891886076)

Local `npx respec --localhost --haltonerror -s index.html -o /dev/null` passes cleanly (exit 0, 0 errors), so the spec content is fine — the regression is in the action.

`v2.12.5` (2026-02-26) is the last release before v2.13.0; pinning to it should restore CI while we wait for upstream to fix the bare-`respec` invocation. No upstream issue is filed yet — happy to file one once we confirm the pin works.

The following tasks have been completed:

 * [x] ~~Modified Web platform tests~~ — CI workflow change only, no spec or observable behavior change.

Implementation commitment:

 * [ ] ~~WebKit~~ — n/a, no observable change
 * [ ] ~~Chromium~~ — n/a, no observable change
 * [ ] ~~Gecko~~ — n/a, no observable change