### PR TITLE
Trigger HTML activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,6 +806,11 @@
           </li>
           <li>If |document| is `null`, abort these steps.
           </li>
+          <li>If |document| is a [=Document/fully active descendant of a
+          top-level traversable with user attention=] and |gamepad|
+          [=contains a gamepad user gesture=], then run the [=activation
+          notification=] steps given |document|.
+          </li>
           <li>If |navigator|.{{Navigator/[[hasGamepadGesture]]}} is `false` and
           |document| is a [=Document/fully active descendant of a top-level
           traversable with user attention=] and |gamepad| [=contains a gamepad
@@ -840,6 +845,20 @@
             </ol>
           </li>
         </ol>
+        <p class="note">
+          This grants [=sticky activation=] and [=transient activation=] to
+          |document|'s [=relevant global object=] (and the other windows
+          covered by the [=activation notification=] steps), the same as
+          other trusted input events do. This lets gamepad button presses and
+          axis movements satisfy [=user activation-gated APIs=], such as
+          {{Element/requestFullscreen()}} and the autoplay policy — matching
+          existing behavior in some [=user agents=]. Unlike
+          {{Navigator/[[hasGamepadGesture]]}}, which latches permanently the
+          first time it is set, this step runs every time |gamepad|
+          [=contains a gamepad user gesture=], matching how other
+          activation-triggering input events grant activation on every
+          occurrence rather than once.
+        </p>
         <p>
           To <dfn>map and normalize axes</dfn> for |gamepad:Gamepad|, run the
           following steps:


### PR DESCRIPTION
Closes #124

This combines gamepad interaction with HTML's existing sticky/transient activation (https://html.spec.whatwg.org/#tracking-user-activation) model, per @marcoscaceres's review on #107 ("we probably want to layer this on top of HTML's 'triggered by user activation'") and this issue's suggestion to use the sticky-activation model directly, rather than defining a new gamepad-local activation concept as #107 attempted (that PR duplicated the existing spec's "contains a gamepad user gesture" definition under a colliding name and never reached HTML's real activation state -- I suggest closing it in favor of this PR).

This also matches existing shipped behavior: Chromium calls LocalFrame::NotifyUserActivation(kInteraction) from NavigatorGamepad::Gamepads() whenever GamepadComparisons::Compare() detects a qualifying button/axis transition on a visible page -- the same primitive mouse/keyboard input uses. This PR gives that behavior normative text, reusing the spec's existing "contains a gamepad user gesture" and fully active descendant of a top-level traversable with user attention conditions as the trigger, and HTML's activationnotification algorithm as the effect.

Note this extends HTML's own introduction of activation notification ("when a user interaction causes firing of an activation triggering input event... the user agent must perform the following steps before dispatching the event") — gamepad state changes aren't dispatched as that kind of event; they're observed by polling. I'm invoking the algorithm as a reusable procedure rather than a hard prerequisite check, consistent with how Chromium implements it (it calls the underlying primitive directly, not by synthesizing a fake input event). Flagging this for HTML editors in case they'd prefer activation-triggering-input-event itself be broadened instead of allowing direct invocation.  I can change to that if requested.

Deliberately out of scope: the separate, older "gamepadconnected event" section (§17) has its own partially-duplicated algorithm with stale prose ("SHOULD be dispatched when the user presses a button or moves an axis") that looks like leftover text update gamepad state was meant to supersede. Left untouched here to keep this PR reviewable; worth a separate cleanup PR.

The following tasks have been completed:

 * [x] Modified Web platform tests (https://bugzilla.mozilla.org/show_bug.cgi?id=2053976)

Implementation commitment:

 * [ ] WebKit
 * [x] Chromium (already implemented)
 * [x] Gecko (tracked in https://bugzilla.mozilla.org/show_bug.cgi?id=1679817 and https://bugzilla.mozilla.org/show_bug.cgi?id=1740573)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jesup/gamepad/pull/230.html" title="Last updated on Jul 10, 2026, 4:09 PM UTC (936b77c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gamepad/230/81ad075...jesup:936b77c.html" title="Last updated on Jul 10, 2026, 4:09 PM UTC (936b77c)">Diff</a>